### PR TITLE
Fix Memory Issues

### DIFF
--- a/BurnOutSharp/BurnOutSharp.nuspec
+++ b/BurnOutSharp/BurnOutSharp.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>BurnOutSharp</id>
-    <version>1.03.8.0</version>
+    <version>1.03.8.1</version>
     <title>BurnOutSharp</title>
     <authors>Matt Nadareski, Gernot Knippen</authors>
     <owners>Matt Nadareski, Gernot Knippen</owners>

--- a/BurnOutSharp/ProtectionType/CactusDataShield.cs
+++ b/BurnOutSharp/ProtectionType/CactusDataShield.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 
 namespace BurnOutSharp.ProtectionType
 {
@@ -11,8 +12,7 @@ namespace BurnOutSharp.ProtectionType
         {
             if (Path.GetFileName(file) == "CDSPlayer.app")
             {
-                using (var fs = File.Open(file, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
-                using (var sr = new StreamReader(fs))
+                using (var sr = new StreamReader(file, Encoding.Default))
                 {
                     return "Cactus Data Shield " + sr.ReadLine().Substring(3) + "(" + sr.ReadLine() + ")";
                 }

--- a/BurnOutSharp/ProtectionType/PSXAntiModchip.cs
+++ b/BurnOutSharp/ProtectionType/PSXAntiModchip.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 
 namespace BurnOutSharp.ProtectionType
 {
@@ -26,27 +27,31 @@ namespace BurnOutSharp.ProtectionType
                 {
                     foreach (string file in files)
                     {
-                        using (var fs = File.Open(file, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
-                        using (var sr = new StreamReader(fs))
+                        // Load the current file content
+                        string fileContent = null;
+                        using (StreamReader sr = new StreamReader(file, Encoding.Default))
                         {
-                            string fileContent = sr.ReadToEnd();
-                            string protection = CheckContents(path, fileContent);
-                            if (!string.IsNullOrWhiteSpace(protection))
-                                return protection;
+                            fileContent = sr.ReadToEnd();
                         }
+
+                        string protection = CheckContents(path, fileContent);
+                        if (!string.IsNullOrWhiteSpace(protection))
+                            return protection;
                     }
                 }
             }
             else
             {
-                using (var fs = File.Open(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
-                using (var sr = new StreamReader(fs))
+                // Load the current file content
+                string fileContent = null;
+                using (StreamReader sr = new StreamReader(path, Encoding.Default))
                 {
-                    string fileContent = sr.ReadToEnd();
-                    string protection = CheckContents(path, fileContent);
-                    if (!string.IsNullOrWhiteSpace(protection))
-                        return protection;
+                    fileContent = sr.ReadToEnd();
                 }
+
+                string protection = CheckContents(path, fileContent);
+                if (!string.IsNullOrWhiteSpace(protection))
+                    return protection;
             }            
 
             return null;

--- a/BurnOutSharp/ProtectionType/PSXAntiModchip.cs
+++ b/BurnOutSharp/ProtectionType/PSXAntiModchip.cs
@@ -39,20 +39,7 @@ namespace BurnOutSharp.ProtectionType
                             return protection;
                     }
                 }
-            }
-            else
-            {
-                // Load the current file content
-                string fileContent = null;
-                using (StreamReader sr = new StreamReader(path, Encoding.Default))
-                {
-                    fileContent = sr.ReadToEnd();
-                }
-
-                string protection = CheckContents(path, fileContent);
-                if (!string.IsNullOrWhiteSpace(protection))
-                    return protection;
-            }            
+            }      
 
             return null;
         }


### PR DESCRIPTION
After the recent reorganization of the code, there ended up being some parts that were less well-formatted than others, which lead to some issues while being used in DICUI. This included out of memory issues on DVD-9 discs. The changes here should reduce the amount of memory that is being used in any given protection scan as well as reduce the amount of time for InstallShield CAB files since all of them scanned every CAB every time.