### PR TITLE
Pathing issues

### DIFF
--- a/BurnOutSharp/BurnOutSharp.nuspec
+++ b/BurnOutSharp/BurnOutSharp.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>BurnOutSharp</id>
-    <version>1.03.8.1</version>
+    <version>1.03.8.2</version>
     <title>BurnOutSharp</title>
     <authors>Matt Nadareski, Gernot Knippen</authors>
     <owners>Matt Nadareski, Gernot Knippen</owners>

--- a/BurnOutSharp/EVORE.cs
+++ b/BurnOutSharp/EVORE.cs
@@ -37,7 +37,7 @@ namespace BurnOutSharp
 
         private static Process StartSafe(string file)
         {
-            if (file == null)
+            if (file == null || !File.Exists(file))
                 return null;
 
             Process startingprocess = new Process();
@@ -59,7 +59,7 @@ namespace BurnOutSharp
 
         private static string MakeTempFile(string file, string sExtension = ".exe")
         {
-            if (file == null)
+            if (file == null || !File.Exists(file))
                 return string.Empty;
 
             FileInfo filei = new FileInfo(file);
@@ -75,7 +75,7 @@ namespace BurnOutSharp
 
         private static bool IsEXE(string file)
         {
-            if (file == null)
+            if (file == null || !File.Exists(file))
                 return false;
 
             BinaryReader breader = new BinaryReader(File.OpenRead(file));
@@ -199,7 +199,7 @@ namespace BurnOutSharp
 
         public static string SearchProtectDiscVersion(string file)
         {
-            if (file == null)
+            if (file == null || !File.Exists(file))
                 return string.Empty;
 
             Process exe = new Process();
@@ -357,7 +357,7 @@ namespace BurnOutSharp
 
         public static string SearchSafeDiscVersion(string file)
         {
-            if (file == null)
+            if (file == null || !File.Exists(file))
                 return string.Empty;
 
             Process exe = new Process();

--- a/BurnOutSharp/ProtectionType/CDCops.cs
+++ b/BurnOutSharp/ProtectionType/CDCops.cs
@@ -49,7 +49,7 @@ namespace BurnOutSharp.ProtectionType
 
         private static string GetVersion(string file, int position)
         {
-            if (file == null)
+            if (file == null || !File.Exists(file))
                 return string.Empty;
 
             using (var fs = File.Open(file, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))

--- a/BurnOutSharp/ProtectionType/DVDCops.cs
+++ b/BurnOutSharp/ProtectionType/DVDCops.cs
@@ -15,7 +15,7 @@ namespace BurnOutSharp.ProtectionType
 
         private static string GetVersion(string file, int position)
         {
-            if (file == null)
+            if (file == null || !File.Exists(file))
                 return string.Empty;
 
             using (var fs = File.Open(file, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))

--- a/BurnOutSharp/ProtectionType/InnoSetup.cs
+++ b/BurnOutSharp/ProtectionType/InnoSetup.cs
@@ -17,7 +17,7 @@ namespace BurnOutSharp.ProtectionType
 
         private static string GetVersion(string file)
         {
-            if (file == null)
+            if (file == null || !File.Exists(file))
                 return string.Empty;
 
             using (var fs = File.Open(file, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))

--- a/BurnOutSharp/ProtectionType/JoWooDXProt.cs
+++ b/BurnOutSharp/ProtectionType/JoWooDXProt.cs
@@ -27,7 +27,7 @@ namespace BurnOutSharp.ProtectionType
 
         private static string GetVersion(string file, int position)
         {
-            if (file == null)
+            if (file == null || !File.Exists(file))
                 return string.Empty;
 
             using (var fs = File.Open(file, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))

--- a/BurnOutSharp/ProtectionType/ProtectDisc.cs
+++ b/BurnOutSharp/ProtectionType/ProtectDisc.cs
@@ -41,7 +41,7 @@ namespace BurnOutSharp.ProtectionType
 
         private static string GetVersionBuild6till8(string file, int position)
         {
-            if (file == null)
+            if (file == null || !File.Exists(file))
                 return string.Empty;
 
             using (var fs = File.Open(file, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
@@ -93,7 +93,7 @@ namespace BurnOutSharp.ProtectionType
         private static string GetVersionBuild76till10(string file, int position, out int irefBuild)
         {
             irefBuild = 0;
-            if (file == null)
+            if (file == null || !File.Exists(file))
                 return string.Empty;
 
             using (var fs = File.Open(file, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))

--- a/BurnOutSharp/ProtectionType/SafeDisc.cs
+++ b/BurnOutSharp/ProtectionType/SafeDisc.cs
@@ -39,15 +39,22 @@ namespace BurnOutSharp.ProtectionType
                 // TODO: These are all cop-outs that don't check the existence of the other files
                 if (files.Count(f => Path.GetFileName(f).Equals("DPLAYERX.DLL", StringComparison.OrdinalIgnoreCase)) > 0)
                 {
-                    return GetDPlayerXVersion(path);
+                    string file = files.First(f => Path.GetFileName(f).Equals("DPLAYERX.DLL", StringComparison.OrdinalIgnoreCase));
+                    return GetDPlayerXVersion(file);
                 }
                 else if (files.Count(f => Path.GetFileName(f).Equals("drvmgt.dll", StringComparison.OrdinalIgnoreCase)) > 0)
                 {
-                    return GetDrvmgtVersion(path);
+                    string file = files.First(f => Path.GetFileName(f).Equals("drvmgt.dll", StringComparison.OrdinalIgnoreCase));
+                    return GetDrvmgtVersion(file);
                 }
                 else if (files.Count(f => Path.GetFileName(f).Equals("secdrv.sys", StringComparison.OrdinalIgnoreCase)) > 0)
                 {
-                    return GetSecdrvVersion(path);
+                    string file = files.First(f => Path.GetFileName(f).Equals("secdrv.sys", StringComparison.OrdinalIgnoreCase));
+                    return GetSecdrvVersion(file);
+                }
+                else if (path.EndsWith(".SafeDiscDVD.bundle", StringComparison.OrdinalIgnoreCase))
+                {
+                    return "SafeDisc for Macintosh";
                 }
             }
             else
@@ -97,7 +104,7 @@ namespace BurnOutSharp.ProtectionType
 
         private static string GetDPlayerXVersion(string file)
         {
-            if (file == null)
+            if (file == null || !File.Exists(file))
                 return string.Empty;
 
             FileInfo fi = new FileInfo(file);
@@ -125,7 +132,7 @@ namespace BurnOutSharp.ProtectionType
 
         private static string GetDrvmgtVersion(string file)
         {
-            if (file == null)
+            if (file == null || !File.Exists(file))
                 return string.Empty;
 
             FileInfo fi = new FileInfo(file);
@@ -153,7 +160,7 @@ namespace BurnOutSharp.ProtectionType
 
         private static string GetSecdrvVersion(string file)
         {
-            if (file == null)
+            if (file == null || !File.Exists(file))
                 return string.Empty;
 
             FileInfo fi = new FileInfo(file);
@@ -187,7 +194,7 @@ namespace BurnOutSharp.ProtectionType
 
         private static string GetVersion(string file, int position)
         {
-            if (file == null)
+            if (file == null || !File.Exists(file))
                 return string.Empty;
 
             using (var fs = File.Open(file, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))

--- a/BurnOutSharp/ProtectionType/SecuROM.cs
+++ b/BurnOutSharp/ProtectionType/SecuROM.cs
@@ -80,7 +80,7 @@ namespace BurnOutSharp.ProtectionType
 
         private static string GetV4Version(string file, int position)
         {
-            if (file == null)
+            if (file == null || !File.Exists(file))
                 return string.Empty;
 
             using (var fs = File.Open(file, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
@@ -106,7 +106,7 @@ namespace BurnOutSharp.ProtectionType
 
         private static string GetV5Version(string file, int position)
         {
-            if (file == null)
+            if (file == null || !File.Exists(file))
                 return string.Empty;
 
             using (var fs = File.Open(file, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
@@ -135,7 +135,7 @@ namespace BurnOutSharp.ProtectionType
 
         private static string GetV7Version(string file)
         {
-            if (file == null)
+            if (file == null || !File.Exists(file))
                 return string.Empty;
 
             using (var fs = File.Open(file, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))

--- a/BurnOutSharp/ProtectionType/SolidShield.cs
+++ b/BurnOutSharp/ProtectionType/SolidShield.cs
@@ -131,7 +131,7 @@ namespace BurnOutSharp.ProtectionType
 
         private static string GetVersion(string file, int position)
         {
-            if (file == null)
+            if (file == null || !File.Exists(file))
                 return string.Empty;
 
             using (var fs = File.Open(file, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))

--- a/BurnOutSharp/ProtectionType/Sysiphus.cs
+++ b/BurnOutSharp/ProtectionType/Sysiphus.cs
@@ -18,7 +18,7 @@ namespace BurnOutSharp.ProtectionType
 
         private static string GetVersion(string file, int position)
         {
-            if (file == null)
+            if (file == null || !File.Exists(file))
                 return string.Empty;
 
             using (var fs = File.Open(file, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))

--- a/BurnOutSharp/ProtectionType/Tages.cs
+++ b/BurnOutSharp/ProtectionType/Tages.cs
@@ -80,7 +80,7 @@ namespace BurnOutSharp.ProtectionType
 
         private static string GetVersion(string file, int position)
         {
-            if (file == null)
+            if (file == null || !File.Exists(file))
                 return string.Empty;
 
             using (var fs = File.Open(file, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))

--- a/BurnOutSharp/ProtectionType/VOBProtectCDDVD.cs
+++ b/BurnOutSharp/ProtectionType/VOBProtectCDDVD.cs
@@ -58,7 +58,7 @@ namespace BurnOutSharp.ProtectionType
 
         private static string GetBuild(string file, int position)
         {
-            if (file == null)
+            if (file == null || !File.Exists(file))
                 return string.Empty;
 
             using (var fs = File.Open(file, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
@@ -76,7 +76,7 @@ namespace BurnOutSharp.ProtectionType
 
         private static string GetOldVersion(string file, int position)
         {
-            if (file == null)
+            if (file == null || !File.Exists(file))
                 return string.Empty;
 
             using (var fs = File.Open(file, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
@@ -98,7 +98,7 @@ namespace BurnOutSharp.ProtectionType
 
         private static string GetVersion(string file, int position)
         {
-            if (file == null)
+            if (file == null || !File.Exists(file))
                 return string.Empty;
 
             using (var fs = File.Open(file, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))

--- a/BurnOutSharp/Utilities.cs
+++ b/BurnOutSharp/Utilities.cs
@@ -14,7 +14,7 @@ namespace BurnOutSharp
         /// </summary>
         public static string GetFileVersion(string file)
         {
-            if (file == null)
+            if (file == null || !File.Exists(file))
                 return string.Empty;
 
             FileVersionInfo fvinfo = FileVersionInfo.GetVersionInfo(file);


### PR DESCRIPTION
This PR addresses 3 distinct things having to do with paths:
- It enables preliminary path-only scanning of SafeDisc for Macintosh
- It fixes path scanning for all other SafeDisc versions (on directory scan)
- It makes sure that all places that only checked for `null` files also check for file existence first