### PR TITLE
Concurrent protection scans per file

### DIFF
--- a/BurnOutSharp/FileType/BFPK.cs
+++ b/BurnOutSharp/FileType/BFPK.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using SharpCompress.Compressors;
@@ -20,7 +19,7 @@ namespace BurnOutSharp.FileType
         }
 
         /// <inheritdoc/>
-        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, string file)
+        public ConcurrentDictionary<string, ConcurrentQueue<string>> Scan(Scanner scanner, string file)
         {
             if (!File.Exists(file))
                 return null;
@@ -32,7 +31,7 @@ namespace BurnOutSharp.FileType
         }
 
         /// <inheritdoc/>
-        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, Stream stream, string file)
+        public ConcurrentDictionary<string, ConcurrentQueue<string>> Scan(Scanner scanner, Stream stream, string file)
         {
             // If the BFPK file itself fails
             try

--- a/BurnOutSharp/FileType/BFPK.cs
+++ b/BurnOutSharp/FileType/BFPK.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
@@ -19,7 +20,7 @@ namespace BurnOutSharp.FileType
         }
 
         /// <inheritdoc/>
-        public Dictionary<string, List<string>> Scan(Scanner scanner, string file)
+        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, string file)
         {
             if (!File.Exists(file))
                 return null;
@@ -31,7 +32,7 @@ namespace BurnOutSharp.FileType
         }
 
         /// <inheritdoc/>
-        public Dictionary<string, List<string>> Scan(Scanner scanner, Stream stream, string file)
+        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, Stream stream, string file)
         {
             // If the BFPK file itself fails
             try

--- a/BurnOutSharp/FileType/BZip2.cs
+++ b/BurnOutSharp/FileType/BZip2.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using SharpCompress.Compressors;
@@ -18,7 +19,7 @@ namespace BurnOutSharp.FileType
         }
 
         /// <inheritdoc/>
-        public Dictionary<string, List<string>> Scan(Scanner scanner, string file)
+        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, string file)
         {
             if (!File.Exists(file))
                 return null;
@@ -30,7 +31,7 @@ namespace BurnOutSharp.FileType
         }
 
         /// <inheritdoc/>
-        public Dictionary<string, List<string>> Scan(Scanner scanner, Stream stream, string file)
+        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, Stream stream, string file)
         {
             // If the BZip2 file itself fails
             try

--- a/BurnOutSharp/FileType/BZip2.cs
+++ b/BurnOutSharp/FileType/BZip2.cs
@@ -19,7 +19,7 @@ namespace BurnOutSharp.FileType
         }
 
         /// <inheritdoc/>
-        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, string file)
+        public ConcurrentDictionary<string, ConcurrentQueue<string>> Scan(Scanner scanner, string file)
         {
             if (!File.Exists(file))
                 return null;
@@ -31,7 +31,7 @@ namespace BurnOutSharp.FileType
         }
 
         /// <inheritdoc/>
-        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, Stream stream, string file)
+        public ConcurrentDictionary<string, ConcurrentQueue<string>> Scan(Scanner scanner, Stream stream, string file)
         {
             // If the BZip2 file itself fails
             try

--- a/BurnOutSharp/FileType/Executable.cs
+++ b/BurnOutSharp/FileType/Executable.cs
@@ -51,7 +51,7 @@ namespace BurnOutSharp.FileType
         }
 
         /// <inheritdoc/>
-        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, string file)
+        public ConcurrentDictionary<string, ConcurrentQueue<string>> Scan(Scanner scanner, string file)
         {
             if (!File.Exists(file))
                 return null;
@@ -63,10 +63,10 @@ namespace BurnOutSharp.FileType
         }
 
         /// <inheritdoc/>
-        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, Stream stream, string file)
+        public ConcurrentDictionary<string, ConcurrentQueue<string>> Scan(Scanner scanner, Stream stream, string file)
         {
             // Files can be protected in multiple ways
-            var protections = new ConcurrentDictionary<string, List<string>>();
+            var protections = new ConcurrentDictionary<string, ConcurrentQueue<string>>();
 
             // Load the current file content
             byte[] fileContent = null;

--- a/BurnOutSharp/FileType/Executable.cs
+++ b/BurnOutSharp/FileType/Executable.cs
@@ -1,9 +1,11 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using System.Threading.Tasks;
 
 namespace BurnOutSharp.FileType
 {
@@ -49,7 +51,7 @@ namespace BurnOutSharp.FileType
         }
 
         /// <inheritdoc/>
-        public Dictionary<string, List<string>> Scan(Scanner scanner, string file)
+        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, string file)
         {
             if (!File.Exists(file))
                 return null;
@@ -61,10 +63,10 @@ namespace BurnOutSharp.FileType
         }
 
         /// <inheritdoc/>
-        public Dictionary<string, List<string>> Scan(Scanner scanner, Stream stream, string file)
+        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, Stream stream, string file)
         {
             // Files can be protected in multiple ways
-            var protections = new Dictionary<string, List<string>>();
+            var protections = new ConcurrentDictionary<string, List<string>>();
 
             // Load the current file content
             byte[] fileContent = null;
@@ -86,7 +88,7 @@ namespace BurnOutSharp.FileType
                 stream.Seek(0, SeekOrigin.Begin);
 
             // Iterate through all content checks
-            foreach (var contentCheckClass in contentCheckClasses)
+            Parallel.ForEach(contentCheckClasses, contentCheckClass =>
             {
                 string protection = contentCheckClass.CheckContents(file, fileContent, scanner.IncludePosition);
 
@@ -108,7 +110,7 @@ namespace BurnOutSharp.FileType
                         Utilities.AppendToDictionary(protections, subProtections);
                     }
                 }
-            }
+            });
 
             return protections;
         }

--- a/BurnOutSharp/FileType/GZIP.cs
+++ b/BurnOutSharp/FileType/GZIP.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using SharpCompress.Archives;
@@ -18,7 +19,7 @@ namespace BurnOutSharp.FileType
         }
 
         /// <inheritdoc/>
-        public Dictionary<string, List<string>> Scan(Scanner scanner, string file)
+        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, string file)
         {
             if (!File.Exists(file))
                 return null;
@@ -30,7 +31,7 @@ namespace BurnOutSharp.FileType
         }
 
         /// <inheritdoc/>
-        public Dictionary<string, List<string>> Scan(Scanner scanner, Stream stream, string file)
+        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, Stream stream, string file)
         {
             // If the gzip file itself fails
             try

--- a/BurnOutSharp/FileType/GZIP.cs
+++ b/BurnOutSharp/FileType/GZIP.cs
@@ -19,7 +19,7 @@ namespace BurnOutSharp.FileType
         }
 
         /// <inheritdoc/>
-        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, string file)
+        public ConcurrentDictionary<string, ConcurrentQueue<string>> Scan(Scanner scanner, string file)
         {
             if (!File.Exists(file))
                 return null;
@@ -31,7 +31,7 @@ namespace BurnOutSharp.FileType
         }
 
         /// <inheritdoc/>
-        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, Stream stream, string file)
+        public ConcurrentDictionary<string, ConcurrentQueue<string>> Scan(Scanner scanner, Stream stream, string file)
         {
             // If the gzip file itself fails
             try

--- a/BurnOutSharp/FileType/InstallShieldCAB.cs
+++ b/BurnOutSharp/FileType/InstallShieldCAB.cs
@@ -19,7 +19,7 @@ namespace BurnOutSharp.FileType
         }
 
         /// <inheritdoc/>
-        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, string file)
+        public ConcurrentDictionary<string, ConcurrentQueue<string>> Scan(Scanner scanner, string file)
         {
             if (!File.Exists(file))
                 return null;
@@ -32,7 +32,7 @@ namespace BurnOutSharp.FileType
 
         // TODO: Add stream opening support
         /// <inheritdoc/>
-        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, Stream stream, string file)
+        public ConcurrentDictionary<string, ConcurrentQueue<string>> Scan(Scanner scanner, Stream stream, string file)
         {
             // Get the name of the first cabinet file or header
             string directory = Path.GetDirectoryName(file);

--- a/BurnOutSharp/FileType/InstallShieldCAB.cs
+++ b/BurnOutSharp/FileType/InstallShieldCAB.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Text.RegularExpressions;
@@ -18,7 +19,7 @@ namespace BurnOutSharp.FileType
         }
 
         /// <inheritdoc/>
-        public Dictionary<string, List<string>> Scan(Scanner scanner, string file)
+        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, string file)
         {
             if (!File.Exists(file))
                 return null;
@@ -31,7 +32,7 @@ namespace BurnOutSharp.FileType
 
         // TODO: Add stream opening support
         /// <inheritdoc/>
-        public Dictionary<string, List<string>> Scan(Scanner scanner, Stream stream, string file)
+        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, Stream stream, string file)
         {
             // Get the name of the first cabinet file or header
             string directory = Path.GetDirectoryName(file);

--- a/BurnOutSharp/FileType/MPQ.cs
+++ b/BurnOutSharp/FileType/MPQ.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using StormLibSharp;
@@ -17,7 +18,7 @@ namespace BurnOutSharp.FileType
         }
 
         /// <inheritdoc/>
-        public Dictionary<string, List<string>> Scan(Scanner scanner, string file)
+        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, string file)
         {
             if (!File.Exists(file))
                 return null;
@@ -30,7 +31,7 @@ namespace BurnOutSharp.FileType
 
         // TODO: Add stream opening support
         /// <inheritdoc/>
-        public Dictionary<string, List<string>> Scan(Scanner scanner, Stream stream, string file)
+        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, Stream stream, string file)
         {
             // If the mpq file itself fails
             try

--- a/BurnOutSharp/FileType/MPQ.cs
+++ b/BurnOutSharp/FileType/MPQ.cs
@@ -18,7 +18,7 @@ namespace BurnOutSharp.FileType
         }
 
         /// <inheritdoc/>
-        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, string file)
+        public ConcurrentDictionary<string, ConcurrentQueue<string>> Scan(Scanner scanner, string file)
         {
             if (!File.Exists(file))
                 return null;
@@ -31,7 +31,7 @@ namespace BurnOutSharp.FileType
 
         // TODO: Add stream opening support
         /// <inheritdoc/>
-        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, Stream stream, string file)
+        public ConcurrentDictionary<string, ConcurrentQueue<string>> Scan(Scanner scanner, Stream stream, string file)
         {
             // If the mpq file itself fails
             try

--- a/BurnOutSharp/FileType/MSI.cs
+++ b/BurnOutSharp/FileType/MSI.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using WixToolset.Dtf.WindowsInstaller;
@@ -17,7 +18,7 @@ namespace BurnOutSharp.FileType
         }
 
         /// <inheritdoc/>
-        public Dictionary<string, List<string>> Scan(Scanner scanner, string file)
+        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, string file)
         {
             if (!File.Exists(file))
                 return null;
@@ -30,7 +31,7 @@ namespace BurnOutSharp.FileType
 
         // TODO: Add stream opening support
         /// <inheritdoc/>
-        public Dictionary<string, List<string>> Scan(Scanner scanner, Stream stream, string file)
+        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, Stream stream, string file)
         {
             // If the MSI file itself fails
             try

--- a/BurnOutSharp/FileType/MSI.cs
+++ b/BurnOutSharp/FileType/MSI.cs
@@ -18,7 +18,7 @@ namespace BurnOutSharp.FileType
         }
 
         /// <inheritdoc/>
-        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, string file)
+        public ConcurrentDictionary<string, ConcurrentQueue<string>> Scan(Scanner scanner, string file)
         {
             if (!File.Exists(file))
                 return null;
@@ -31,7 +31,7 @@ namespace BurnOutSharp.FileType
 
         // TODO: Add stream opening support
         /// <inheritdoc/>
-        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, Stream stream, string file)
+        public ConcurrentDictionary<string, ConcurrentQueue<string>> Scan(Scanner scanner, Stream stream, string file)
         {
             // If the MSI file itself fails
             try

--- a/BurnOutSharp/FileType/MicrosoftCAB.cs
+++ b/BurnOutSharp/FileType/MicrosoftCAB.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using LibMSPackN;
@@ -18,7 +19,7 @@ namespace BurnOutSharp.FileType
         }
 
         /// <inheritdoc/>
-        public Dictionary<string, List<string>> Scan(Scanner scanner, string file)
+        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, string file)
         {
             if (!File.Exists(file))
                 return null;
@@ -31,7 +32,7 @@ namespace BurnOutSharp.FileType
 
         // TODO: Add stream opening support
         /// <inheritdoc/>
-        public Dictionary<string, List<string>> Scan(Scanner scanner, Stream stream, string file)
+        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, Stream stream, string file)
         {
             // If the cab file itself fails
             try

--- a/BurnOutSharp/FileType/MicrosoftCAB.cs
+++ b/BurnOutSharp/FileType/MicrosoftCAB.cs
@@ -19,7 +19,7 @@ namespace BurnOutSharp.FileType
         }
 
         /// <inheritdoc/>
-        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, string file)
+        public ConcurrentDictionary<string, ConcurrentQueue<string>> Scan(Scanner scanner, string file)
         {
             if (!File.Exists(file))
                 return null;
@@ -32,7 +32,7 @@ namespace BurnOutSharp.FileType
 
         // TODO: Add stream opening support
         /// <inheritdoc/>
-        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, Stream stream, string file)
+        public ConcurrentDictionary<string, ConcurrentQueue<string>> Scan(Scanner scanner, Stream stream, string file)
         {
             // If the cab file itself fails
             try

--- a/BurnOutSharp/FileType/PKZIP.cs
+++ b/BurnOutSharp/FileType/PKZIP.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using SharpCompress.Archives;
@@ -27,7 +28,7 @@ namespace BurnOutSharp.FileType
         }
 
         /// <inheritdoc/>
-        public Dictionary<string, List<string>> Scan(Scanner scanner, string file)
+        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, string file)
         {
             if (!File.Exists(file))
                 return null;
@@ -39,7 +40,7 @@ namespace BurnOutSharp.FileType
         }
 
         /// <inheritdoc/>
-        public Dictionary<string, List<string>> Scan(Scanner scanner, Stream stream, string file)
+        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, Stream stream, string file)
         {
             // If the zip file itself fails
             try

--- a/BurnOutSharp/FileType/PKZIP.cs
+++ b/BurnOutSharp/FileType/PKZIP.cs
@@ -28,7 +28,7 @@ namespace BurnOutSharp.FileType
         }
 
         /// <inheritdoc/>
-        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, string file)
+        public ConcurrentDictionary<string, ConcurrentQueue<string>> Scan(Scanner scanner, string file)
         {
             if (!File.Exists(file))
                 return null;
@@ -40,7 +40,7 @@ namespace BurnOutSharp.FileType
         }
 
         /// <inheritdoc/>
-        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, Stream stream, string file)
+        public ConcurrentDictionary<string, ConcurrentQueue<string>> Scan(Scanner scanner, Stream stream, string file)
         {
             // If the zip file itself fails
             try

--- a/BurnOutSharp/FileType/RAR.cs
+++ b/BurnOutSharp/FileType/RAR.cs
@@ -24,7 +24,7 @@ namespace BurnOutSharp.FileType
         }
 
         /// <inheritdoc/>
-        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, string file)
+        public ConcurrentDictionary<string, ConcurrentQueue<string>> Scan(Scanner scanner, string file)
         {
             if (!File.Exists(file))
                 return null;
@@ -36,7 +36,7 @@ namespace BurnOutSharp.FileType
         }
 
         /// <inheritdoc/>
-        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, Stream stream, string file)
+        public ConcurrentDictionary<string, ConcurrentQueue<string>> Scan(Scanner scanner, Stream stream, string file)
         {
             // If the rar file itself fails
             try

--- a/BurnOutSharp/FileType/RAR.cs
+++ b/BurnOutSharp/FileType/RAR.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using SharpCompress.Archives;
@@ -23,7 +24,7 @@ namespace BurnOutSharp.FileType
         }
 
         /// <inheritdoc/>
-        public Dictionary<string, List<string>> Scan(Scanner scanner, string file)
+        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, string file)
         {
             if (!File.Exists(file))
                 return null;
@@ -35,7 +36,7 @@ namespace BurnOutSharp.FileType
         }
 
         /// <inheritdoc/>
-        public Dictionary<string, List<string>> Scan(Scanner scanner, Stream stream, string file)
+        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, Stream stream, string file)
         {
             // If the rar file itself fails
             try

--- a/BurnOutSharp/FileType/SevenZip.cs
+++ b/BurnOutSharp/FileType/SevenZip.cs
@@ -19,7 +19,7 @@ namespace BurnOutSharp.FileType
         }
 
         /// <inheritdoc/>
-        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, string file)
+        public ConcurrentDictionary<string, ConcurrentQueue<string>> Scan(Scanner scanner, string file)
         {
             if (!File.Exists(file))
                 return null;
@@ -31,7 +31,7 @@ namespace BurnOutSharp.FileType
         }
 
         /// <inheritdoc/>
-        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, Stream stream, string file)
+        public ConcurrentDictionary<string, ConcurrentQueue<string>> Scan(Scanner scanner, Stream stream, string file)
         {
             // If the 7-zip file itself fails
             try

--- a/BurnOutSharp/FileType/SevenZip.cs
+++ b/BurnOutSharp/FileType/SevenZip.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using SharpCompress.Archives;
@@ -18,7 +19,7 @@ namespace BurnOutSharp.FileType
         }
 
         /// <inheritdoc/>
-        public Dictionary<string, List<string>> Scan(Scanner scanner, string file)
+        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, string file)
         {
             if (!File.Exists(file))
                 return null;
@@ -30,7 +31,7 @@ namespace BurnOutSharp.FileType
         }
 
         /// <inheritdoc/>
-        public Dictionary<string, List<string>> Scan(Scanner scanner, Stream stream, string file)
+        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, Stream stream, string file)
         {
             // If the 7-zip file itself fails
             try

--- a/BurnOutSharp/FileType/TapeArchive.cs
+++ b/BurnOutSharp/FileType/TapeArchive.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using SharpCompress.Archives;
@@ -21,7 +22,7 @@ namespace BurnOutSharp.FileType
         }
 
         /// <inheritdoc/>
-        public Dictionary<string, List<string>> Scan(Scanner scanner, string file)
+        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, string file)
         {
             if (!File.Exists(file))
                 return null;
@@ -33,7 +34,7 @@ namespace BurnOutSharp.FileType
         }
 
         /// <inheritdoc/>
-        public Dictionary<string, List<string>> Scan(Scanner scanner, Stream stream, string file)
+        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, Stream stream, string file)
         {
             // If the tar file itself fails
             try

--- a/BurnOutSharp/FileType/TapeArchive.cs
+++ b/BurnOutSharp/FileType/TapeArchive.cs
@@ -22,7 +22,7 @@ namespace BurnOutSharp.FileType
         }
 
         /// <inheritdoc/>
-        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, string file)
+        public ConcurrentDictionary<string, ConcurrentQueue<string>> Scan(Scanner scanner, string file)
         {
             if (!File.Exists(file))
                 return null;
@@ -34,7 +34,7 @@ namespace BurnOutSharp.FileType
         }
 
         /// <inheritdoc/>
-        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, Stream stream, string file)
+        public ConcurrentDictionary<string, ConcurrentQueue<string>> Scan(Scanner scanner, Stream stream, string file)
         {
             // If the tar file itself fails
             try

--- a/BurnOutSharp/FileType/Textfile.cs
+++ b/BurnOutSharp/FileType/Textfile.cs
@@ -46,7 +46,7 @@ namespace BurnOutSharp.FileType
         }
 
         /// <inheritdoc/>
-        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, string file)
+        public ConcurrentDictionary<string, ConcurrentQueue<string>> Scan(Scanner scanner, string file)
         {
             if (!File.Exists(file))
                 return null;
@@ -58,10 +58,10 @@ namespace BurnOutSharp.FileType
         }
 
         /// <inheritdoc/>
-        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, Stream stream, string file)
+        public ConcurrentDictionary<string, ConcurrentQueue<string>> Scan(Scanner scanner, Stream stream, string file)
         {
             // Files can be protected in multiple ways
-            var protections = new ConcurrentDictionary<string, List<string>>();
+            var protections = new ConcurrentDictionary<string, ConcurrentQueue<string>>();
 
             try
             {

--- a/BurnOutSharp/FileType/Textfile.cs
+++ b/BurnOutSharp/FileType/Textfile.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
@@ -45,7 +46,7 @@ namespace BurnOutSharp.FileType
         }
 
         /// <inheritdoc/>
-        public Dictionary<string, List<string>> Scan(Scanner scanner, string file)
+        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, string file)
         {
             if (!File.Exists(file))
                 return null;
@@ -57,10 +58,10 @@ namespace BurnOutSharp.FileType
         }
 
         /// <inheritdoc/>
-        public Dictionary<string, List<string>> Scan(Scanner scanner, Stream stream, string file)
+        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, Stream stream, string file)
         {
             // Files can be protected in multiple ways
-            var protections = new Dictionary<string, List<string>>();
+            var protections = new ConcurrentDictionary<string, List<string>>();
 
             try
             {

--- a/BurnOutSharp/FileType/Valve.cs
+++ b/BurnOutSharp/FileType/Valve.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Runtime.InteropServices;
@@ -34,7 +35,7 @@ namespace BurnOutSharp.FileType
         }
 
         /// <inheritdoc/>
-        public Dictionary<string, List<string>> Scan(Scanner scanner, string file)
+        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, string file)
         {
             if (!File.Exists(file))
                 return null;
@@ -47,7 +48,7 @@ namespace BurnOutSharp.FileType
 
         // TODO: Add stream opening support
         /// <inheritdoc/>
-        public Dictionary<string, List<string>> Scan(Scanner scanner, Stream stream, string file)
+        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, Stream stream, string file)
         {
             string tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
             Directory.CreateDirectory(tempPath);

--- a/BurnOutSharp/FileType/Valve.cs
+++ b/BurnOutSharp/FileType/Valve.cs
@@ -35,7 +35,7 @@ namespace BurnOutSharp.FileType
         }
 
         /// <inheritdoc/>
-        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, string file)
+        public ConcurrentDictionary<string, ConcurrentQueue<string>> Scan(Scanner scanner, string file)
         {
             if (!File.Exists(file))
                 return null;
@@ -48,7 +48,7 @@ namespace BurnOutSharp.FileType
 
         // TODO: Add stream opening support
         /// <inheritdoc/>
-        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, Stream stream, string file)
+        public ConcurrentDictionary<string, ConcurrentQueue<string>> Scan(Scanner scanner, Stream stream, string file)
         {
             string tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
             Directory.CreateDirectory(tempPath);

--- a/BurnOutSharp/FileType/XZ.cs
+++ b/BurnOutSharp/FileType/XZ.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using SharpCompress.Compressors.Xz;
@@ -17,7 +18,7 @@ namespace BurnOutSharp.FileType
         }
 
         /// <inheritdoc/>
-        public Dictionary<string, List<string>> Scan(Scanner scanner, string file)
+        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, string file)
         {
             if (!File.Exists(file))
                 return null;
@@ -29,7 +30,7 @@ namespace BurnOutSharp.FileType
         }
 
         /// <inheritdoc/>
-        public Dictionary<string, List<string>> Scan(Scanner scanner, Stream stream, string file)
+        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, Stream stream, string file)
         {
             // If the xz file itself fails
             try

--- a/BurnOutSharp/FileType/XZ.cs
+++ b/BurnOutSharp/FileType/XZ.cs
@@ -18,7 +18,7 @@ namespace BurnOutSharp.FileType
         }
 
         /// <inheritdoc/>
-        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, string file)
+        public ConcurrentDictionary<string, ConcurrentQueue<string>> Scan(Scanner scanner, string file)
         {
             if (!File.Exists(file))
                 return null;
@@ -30,7 +30,7 @@ namespace BurnOutSharp.FileType
         }
 
         /// <inheritdoc/>
-        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, Stream stream, string file)
+        public ConcurrentDictionary<string, ConcurrentQueue<string>> Scan(Scanner scanner, Stream stream, string file)
         {
             // If the xz file itself fails
             try

--- a/BurnOutSharp/IPathCheck.cs
+++ b/BurnOutSharp/IPathCheck.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections.Concurrent;
+using System.Collections.Generic;
 
 namespace BurnOutSharp
 {
@@ -10,7 +11,7 @@ namespace BurnOutSharp
         /// <param name="path">Path to check for protection indicators</param>
         /// <param name="files">Enumerable of strings representing files in a directory</param>
         /// <remarks>This can do some limited content checking as well, but it's suggested to use IContentCheck instead, if possible</remarks>
-        List<string> CheckDirectoryPath(string path, IEnumerable<string> files);
+        ConcurrentQueue<string> CheckDirectoryPath(string path, IEnumerable<string> files);
 
         /// <summary>
         /// Check a file path for protections based on path name

--- a/BurnOutSharp/IScannable.cs
+++ b/BurnOutSharp/IScannable.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.IO;
 
 namespace BurnOutSharp
@@ -19,7 +20,7 @@ namespace BurnOutSharp
         /// <param name="file">Path to the input file</param>
         /// <returns>Dictionary mapping paths to protection lists</returns>
         /// <remarks>Ideally, this should just point to the other scan implementation</remarks>
-        Dictionary<string, List<string>> Scan(Scanner scanner, string file);
+        ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, string file);
 
         /// <summary>
         /// Scan a stream for all internal protections
@@ -28,6 +29,6 @@ namespace BurnOutSharp
         /// <param name="stream">Stream representing the input file</param>
         /// <param name="file">Path to the input file</param>
         /// <returns>Dictionary mapping paths to protection lists</returns>
-        Dictionary<string, List<string>> Scan(Scanner scanner, Stream stream, string filename);
+        ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, Stream stream, string filename);
     }
 }

--- a/BurnOutSharp/IScannable.cs
+++ b/BurnOutSharp/IScannable.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.IO;
 
 namespace BurnOutSharp
@@ -20,7 +19,7 @@ namespace BurnOutSharp
         /// <param name="file">Path to the input file</param>
         /// <returns>Dictionary mapping paths to protection lists</returns>
         /// <remarks>Ideally, this should just point to the other scan implementation</remarks>
-        ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, string file);
+        ConcurrentDictionary<string, ConcurrentQueue<string>> Scan(Scanner scanner, string file);
 
         /// <summary>
         /// Scan a stream for all internal protections
@@ -29,6 +28,6 @@ namespace BurnOutSharp
         /// <param name="stream">Stream representing the input file</param>
         /// <param name="file">Path to the input file</param>
         /// <returns>Dictionary mapping paths to protection lists</returns>
-        ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, Stream stream, string filename);
+        ConcurrentDictionary<string, ConcurrentQueue<string>> Scan(Scanner scanner, Stream stream, string filename);
     }
 }

--- a/BurnOutSharp/PackerType/CExe.cs
+++ b/BurnOutSharp/PackerType/CExe.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using BurnOutSharp.Matching;
@@ -33,7 +34,7 @@ namespace BurnOutSharp.PackerType
         }
 
         /// <inheritdoc/>
-        public Dictionary<string, List<string>> Scan(Scanner scanner, string file)
+        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, string file)
         {
             if (!File.Exists(file))
                 return null;
@@ -46,7 +47,7 @@ namespace BurnOutSharp.PackerType
 
         /// <inheritdoc/>
         // TODO: Add extraction if viable
-        public Dictionary<string, List<string>> Scan(Scanner scanner, Stream stream, string file)
+        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, Stream stream, string file)
         {
             return null;
         }

--- a/BurnOutSharp/PackerType/CExe.cs
+++ b/BurnOutSharp/PackerType/CExe.cs
@@ -34,7 +34,7 @@ namespace BurnOutSharp.PackerType
         }
 
         /// <inheritdoc/>
-        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, string file)
+        public ConcurrentDictionary<string, ConcurrentQueue<string>> Scan(Scanner scanner, string file)
         {
             if (!File.Exists(file))
                 return null;
@@ -47,7 +47,7 @@ namespace BurnOutSharp.PackerType
 
         /// <inheritdoc/>
         // TODO: Add extraction if viable
-        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, Stream stream, string file)
+        public ConcurrentDictionary<string, ConcurrentQueue<string>> Scan(Scanner scanner, Stream stream, string file)
         {
             return null;
         }

--- a/BurnOutSharp/PackerType/InnoSetup.cs
+++ b/BurnOutSharp/PackerType/InnoSetup.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -36,7 +37,7 @@ namespace BurnOutSharp.PackerType
         }
 
         /// <inheritdoc/>
-        public Dictionary<string, List<string>> Scan(Scanner scanner, string file)
+        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, string file)
         {
             if (!File.Exists(file))
                 return null;
@@ -50,7 +51,7 @@ namespace BurnOutSharp.PackerType
         // TOOO: Add Inno Setup extraction
         // https://github.com/dscharrer/InnoExtract
         /// <inheritdoc/>
-        public Dictionary<string, List<string>> Scan(Scanner scanner, Stream stream, string file)
+        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, Stream stream, string file)
         {
             return null;
         }

--- a/BurnOutSharp/PackerType/InnoSetup.cs
+++ b/BurnOutSharp/PackerType/InnoSetup.cs
@@ -37,7 +37,7 @@ namespace BurnOutSharp.PackerType
         }
 
         /// <inheritdoc/>
-        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, string file)
+        public ConcurrentDictionary<string, ConcurrentQueue<string>> Scan(Scanner scanner, string file)
         {
             if (!File.Exists(file))
                 return null;
@@ -51,7 +51,7 @@ namespace BurnOutSharp.PackerType
         // TOOO: Add Inno Setup extraction
         // https://github.com/dscharrer/InnoExtract
         /// <inheritdoc/>
-        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, Stream stream, string file)
+        public ConcurrentDictionary<string, ConcurrentQueue<string>> Scan(Scanner scanner, Stream stream, string file)
         {
             return null;
         }

--- a/BurnOutSharp/PackerType/InstallerVISE.cs
+++ b/BurnOutSharp/PackerType/InstallerVISE.cs
@@ -29,7 +29,7 @@ namespace BurnOutSharp.PackerType
         // TODO: Add Installer VISE extraction
         // https://github.com/Bioruebe/UniExtract2
         /// <inheritdoc/>
-        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, string file)
+        public ConcurrentDictionary<string, ConcurrentQueue<string>> Scan(Scanner scanner, string file)
         {
             if (!File.Exists(file))
                 return null;
@@ -41,7 +41,7 @@ namespace BurnOutSharp.PackerType
         }
 
         /// <inheritdoc/>
-        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, Stream stream, string file)
+        public ConcurrentDictionary<string, ConcurrentQueue<string>> Scan(Scanner scanner, Stream stream, string file)
         {
             return null;
         }

--- a/BurnOutSharp/PackerType/InstallerVISE.cs
+++ b/BurnOutSharp/PackerType/InstallerVISE.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using BurnOutSharp.Matching;
@@ -28,7 +29,7 @@ namespace BurnOutSharp.PackerType
         // TODO: Add Installer VISE extraction
         // https://github.com/Bioruebe/UniExtract2
         /// <inheritdoc/>
-        public Dictionary<string, List<string>> Scan(Scanner scanner, string file)
+        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, string file)
         {
             if (!File.Exists(file))
                 return null;
@@ -40,7 +41,7 @@ namespace BurnOutSharp.PackerType
         }
 
         /// <inheritdoc/>
-        public Dictionary<string, List<string>> Scan(Scanner scanner, Stream stream, string file)
+        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, Stream stream, string file)
         {
             return null;
         }

--- a/BurnOutSharp/PackerType/SetupFactory.cs
+++ b/BurnOutSharp/PackerType/SetupFactory.cs
@@ -49,7 +49,7 @@ namespace BurnOutSharp.PackerType
         }
 
         /// <inheritdoc/>
-        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, string file)
+        public ConcurrentDictionary<string, ConcurrentQueue<string>> Scan(Scanner scanner, string file)
         {
             if (!File.Exists(file))
                 return null;
@@ -63,7 +63,7 @@ namespace BurnOutSharp.PackerType
         /// <inheritdoc/>
         // TODO: Add extraction, which is possible but the only tools available that can
         // do this seem to be Universal Extractor 2 and InstallExplorer (https://totalcmd.net/plugring/InstallExplorer.html)
-        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, Stream stream, string file)
+        public ConcurrentDictionary<string, ConcurrentQueue<string>> Scan(Scanner scanner, Stream stream, string file)
         {
             return null;
         }

--- a/BurnOutSharp/PackerType/SetupFactory.cs
+++ b/BurnOutSharp/PackerType/SetupFactory.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.IO;
 using BurnOutSharp.Matching;
 
@@ -48,7 +49,7 @@ namespace BurnOutSharp.PackerType
         }
 
         /// <inheritdoc/>
-        public Dictionary<string, List<string>> Scan(Scanner scanner, string file)
+        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, string file)
         {
             if (!File.Exists(file))
                 return null;
@@ -62,7 +63,7 @@ namespace BurnOutSharp.PackerType
         /// <inheritdoc/>
         // TODO: Add extraction, which is possible but the only tools available that can
         // do this seem to be Universal Extractor 2 and InstallExplorer (https://totalcmd.net/plugring/InstallExplorer.html)
-        public Dictionary<string, List<string>> Scan(Scanner scanner, Stream stream, string file)
+        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, Stream stream, string file)
         {
             return null;
         }

--- a/BurnOutSharp/PackerType/WinRARSFX.cs
+++ b/BurnOutSharp/PackerType/WinRARSFX.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using BurnOutSharp.Matching;
@@ -29,7 +30,7 @@ namespace BurnOutSharp.PackerType
             return MatchUtil.GetFirstMatch(file, fileContent, matchers, includePosition);
         }
 
-        public Dictionary<string, List<string>> Scan(Scanner scanner, string file)
+        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, string file)
         {
             if (!File.Exists(file))
                 return null;
@@ -41,7 +42,7 @@ namespace BurnOutSharp.PackerType
         }
 
         /// <inheritdoc/>
-        public Dictionary<string, List<string>> Scan(Scanner scanner, Stream stream, string file)
+        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, Stream stream, string file)
         {
             // If the rar file itself fails
             try

--- a/BurnOutSharp/PackerType/WinRARSFX.cs
+++ b/BurnOutSharp/PackerType/WinRARSFX.cs
@@ -30,7 +30,7 @@ namespace BurnOutSharp.PackerType
             return MatchUtil.GetFirstMatch(file, fileContent, matchers, includePosition);
         }
 
-        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, string file)
+        public ConcurrentDictionary<string, ConcurrentQueue<string>> Scan(Scanner scanner, string file)
         {
             if (!File.Exists(file))
                 return null;
@@ -42,7 +42,7 @@ namespace BurnOutSharp.PackerType
         }
 
         /// <inheritdoc/>
-        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, Stream stream, string file)
+        public ConcurrentDictionary<string, ConcurrentQueue<string>> Scan(Scanner scanner, Stream stream, string file)
         {
             // If the rar file itself fails
             try

--- a/BurnOutSharp/PackerType/WinZipSFX.cs
+++ b/BurnOutSharp/PackerType/WinZipSFX.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using BurnOutSharp.Matching;
@@ -35,7 +36,7 @@ namespace BurnOutSharp.PackerType
         // TODO: Find a way to generically detect 2.X versions and improve exact version detection for SFX PE versions bundled with WinZip 11+
 
         /// <inheritdoc/>
-        public Dictionary<string, List<string>> Scan(Scanner scanner, string file)
+        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, string file)
         {
             if (!File.Exists(file))
                 return null;
@@ -47,7 +48,7 @@ namespace BurnOutSharp.PackerType
         }
 
         /// <inheritdoc/>
-        public Dictionary<string, List<string>> Scan(Scanner scanner, Stream stream, string file)
+        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, Stream stream, string file)
         {
             // If the zip file itself fails
             try

--- a/BurnOutSharp/PackerType/WinZipSFX.cs
+++ b/BurnOutSharp/PackerType/WinZipSFX.cs
@@ -36,7 +36,7 @@ namespace BurnOutSharp.PackerType
         // TODO: Find a way to generically detect 2.X versions and improve exact version detection for SFX PE versions bundled with WinZip 11+
 
         /// <inheritdoc/>
-        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, string file)
+        public ConcurrentDictionary<string, ConcurrentQueue<string>> Scan(Scanner scanner, string file)
         {
             if (!File.Exists(file))
                 return null;
@@ -48,7 +48,7 @@ namespace BurnOutSharp.PackerType
         }
 
         /// <inheritdoc/>
-        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, Stream stream, string file)
+        public ConcurrentDictionary<string, ConcurrentQueue<string>> Scan(Scanner scanner, Stream stream, string file)
         {
             // If the zip file itself fails
             try

--- a/BurnOutSharp/PackerType/WiseInstaller.cs
+++ b/BurnOutSharp/PackerType/WiseInstaller.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using BurnOutSharp.Matching;
@@ -24,7 +25,7 @@ namespace BurnOutSharp.PackerType
         }
 
         /// <inheritdoc/>
-        public Dictionary<string, List<string>> Scan(Scanner scanner, string file)
+        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, string file)
         {
             if (!File.Exists(file))
                 return null;
@@ -36,7 +37,7 @@ namespace BurnOutSharp.PackerType
         }
 
         /// <inheritdoc/>
-        public Dictionary<string, List<string>> Scan(Scanner scanner, Stream stream, string file)
+        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, Stream stream, string file)
         {
             // If the installer file itself fails
             try

--- a/BurnOutSharp/PackerType/WiseInstaller.cs
+++ b/BurnOutSharp/PackerType/WiseInstaller.cs
@@ -25,7 +25,7 @@ namespace BurnOutSharp.PackerType
         }
 
         /// <inheritdoc/>
-        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, string file)
+        public ConcurrentDictionary<string, ConcurrentQueue<string>> Scan(Scanner scanner, string file)
         {
             if (!File.Exists(file))
                 return null;
@@ -37,7 +37,7 @@ namespace BurnOutSharp.PackerType
         }
 
         /// <inheritdoc/>
-        public ConcurrentDictionary<string, List<string>> Scan(Scanner scanner, Stream stream, string file)
+        public ConcurrentDictionary<string, ConcurrentQueue<string>> Scan(Scanner scanner, Stream stream, string file)
         {
             // If the installer file itself fails
             try

--- a/BurnOutSharp/ProtectionType/AACS.cs
+++ b/BurnOutSharp/ProtectionType/AACS.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.IO;
 using BurnOutSharp.Matching;
 
@@ -7,7 +8,7 @@ namespace BurnOutSharp.ProtectionType
     public class AACS : IPathCheck
     {
         /// <inheritdoc/>
-        public List<string> CheckDirectoryPath(string path, IEnumerable<string> files)
+        public ConcurrentQueue<string> CheckDirectoryPath(string path, IEnumerable<string> files)
         {
             var matchers = new List<PathMatchSet>
             {

--- a/BurnOutSharp/ProtectionType/AlphaDVD.cs
+++ b/BurnOutSharp/ProtectionType/AlphaDVD.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections.Concurrent;
+using System.Collections.Generic;
 using BurnOutSharp.Matching;
 
 namespace BurnOutSharp.ProtectionType
@@ -6,7 +7,7 @@ namespace BurnOutSharp.ProtectionType
     public class AlphaDVD : IPathCheck
     {
         /// <inheritdoc/>
-        public List<string> CheckDirectoryPath(string path, IEnumerable<string> files)
+        public ConcurrentQueue<string> CheckDirectoryPath(string path, IEnumerable<string> files)
         {
             var matchers = new List<PathMatchSet>
             {

--- a/BurnOutSharp/ProtectionType/BDPlus.cs
+++ b/BurnOutSharp/ProtectionType/BDPlus.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -9,7 +10,7 @@ namespace BurnOutSharp.ProtectionType
     public class BDPlus : IPathCheck
     {
         /// <inheritdoc/>
-        public List<string> CheckDirectoryPath(string path, IEnumerable<string> files)
+        public ConcurrentQueue<string> CheckDirectoryPath(string path, IEnumerable<string> files)
         {
             var matchers = new List<PathMatchSet>
             {

--- a/BurnOutSharp/ProtectionType/Bitpool.cs
+++ b/BurnOutSharp/ProtectionType/Bitpool.cs
@@ -1,5 +1,6 @@
-﻿using BurnOutSharp.Matching;
+﻿using System.Collections.Concurrent;
 using System.Collections.Generic;
+using BurnOutSharp.Matching;
 
 namespace BurnOutSharp.ProtectionType
 {
@@ -29,7 +30,7 @@ namespace BurnOutSharp.ProtectionType
         }
 
         /// <inheritdoc/>
-        public List<string> CheckDirectoryPath(string path, IEnumerable<string> files)
+        public ConcurrentQueue<string> CheckDirectoryPath(string path, IEnumerable<string> files)
         {
             var matchers = new List<PathMatchSet>
             {

--- a/BurnOutSharp/ProtectionType/ByteShield.cs
+++ b/BurnOutSharp/ProtectionType/ByteShield.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections.Concurrent;
+using System.Collections.Generic;
 using BurnOutSharp.Matching;
 
 namespace BurnOutSharp.ProtectionType
@@ -6,7 +7,7 @@ namespace BurnOutSharp.ProtectionType
     public class ByteShield : IPathCheck
     {
         /// <inheritdoc/>
-        public List<string> CheckDirectoryPath(string path, IEnumerable<string> files)
+        public ConcurrentQueue<string> CheckDirectoryPath(string path, IEnumerable<string> files)
         {
             var matchers = new List<PathMatchSet>
             {

--- a/BurnOutSharp/ProtectionType/CDCops.cs
+++ b/BurnOutSharp/ProtectionType/CDCops.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using BurnOutSharp.Matching;
@@ -27,7 +28,7 @@ namespace BurnOutSharp.ProtectionType
         }
 
         /// <inheritdoc/>
-        public List<string> CheckDirectoryPath(string path, IEnumerable<string> files)
+        public ConcurrentQueue<string> CheckDirectoryPath(string path, IEnumerable<string> files)
         {
             // TODO: Original had "CDCOPS.DLL" required and all the rest in a combined OR
             var matchers = new List<PathMatchSet>

--- a/BurnOutSharp/ProtectionType/CDLock.cs
+++ b/BurnOutSharp/ProtectionType/CDLock.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections.Concurrent;
+using System.Collections.Generic;
 using BurnOutSharp.Matching;
 
 namespace BurnOutSharp.ProtectionType
@@ -24,7 +25,7 @@ namespace BurnOutSharp.ProtectionType
         }
 
         /// <inheritdoc/>
-        public List<string> CheckDirectoryPath(string path, IEnumerable<string> files)
+        public ConcurrentQueue<string> CheckDirectoryPath(string path, IEnumerable<string> files)
         {
             var matchers = new List<PathMatchSet>
             {

--- a/BurnOutSharp/ProtectionType/CDProtector.cs
+++ b/BurnOutSharp/ProtectionType/CDProtector.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections.Concurrent;
+using System.Collections.Generic;
 using BurnOutSharp.Matching;
 
 namespace BurnOutSharp.ProtectionType
@@ -6,7 +7,7 @@ namespace BurnOutSharp.ProtectionType
     public class CDProtector : IPathCheck
     {
         /// <inheritdoc/>
-        public List<string> CheckDirectoryPath(string path, IEnumerable<string> files)
+        public ConcurrentQueue<string> CheckDirectoryPath(string path, IEnumerable<string> files)
         {
             // TODO: Verify if these are OR or AND
             var matchers = new List<PathMatchSet>

--- a/BurnOutSharp/ProtectionType/CDX.cs
+++ b/BurnOutSharp/ProtectionType/CDX.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections.Concurrent;
+using System.Collections.Generic;
 using BurnOutSharp.Matching;
 
 namespace BurnOutSharp.ProtectionType
@@ -6,7 +7,7 @@ namespace BurnOutSharp.ProtectionType
     public class CDX : IPathCheck
     {
         /// <inheritdoc/>
-        public List<string> CheckDirectoryPath(string path, IEnumerable<string> files)
+        public ConcurrentQueue<string> CheckDirectoryPath(string path, IEnumerable<string> files)
         {
             // TODO: Verify if these are OR or AND
             var matchers = new List<PathMatchSet>

--- a/BurnOutSharp/ProtectionType/CactusDataShield.cs
+++ b/BurnOutSharp/ProtectionType/CactusDataShield.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -28,7 +29,7 @@ namespace BurnOutSharp.ProtectionType
         }
 
         /// <inheritdoc/>
-        public List<string> CheckDirectoryPath(string path, IEnumerable<string> files)
+        public ConcurrentQueue<string> CheckDirectoryPath(string path, IEnumerable<string> files)
         {
             // TODO: Verify if these are OR or AND
             var matchers = new List<PathMatchSet>

--- a/BurnOutSharp/ProtectionType/CopyKiller.cs
+++ b/BurnOutSharp/ProtectionType/CopyKiller.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections.Concurrent;
+using System.Collections.Generic;
 using BurnOutSharp.Matching;
 
 namespace BurnOutSharp.ProtectionType
@@ -22,7 +23,7 @@ namespace BurnOutSharp.ProtectionType
         }
 
         /// <inheritdoc/>
-        public List<string> CheckDirectoryPath(string path, IEnumerable<string> files)
+        public ConcurrentQueue<string> CheckDirectoryPath(string path, IEnumerable<string> files)
         {
             // TODO: The following checks are overly broad and should be refined
             var matchers = new List<PathMatchSet>

--- a/BurnOutSharp/ProtectionType/DVDCrypt.cs
+++ b/BurnOutSharp/ProtectionType/DVDCrypt.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections.Concurrent;
+using System.Collections.Generic;
 using BurnOutSharp.Matching;
 
 namespace BurnOutSharp.ProtectionType
@@ -6,7 +7,7 @@ namespace BurnOutSharp.ProtectionType
     public class DVDCrypt : IPathCheck
     {
         /// <inheritdoc/>
-        public List<string> CheckDirectoryPath(string path, IEnumerable<string> files)
+        public ConcurrentQueue<string> CheckDirectoryPath(string path, IEnumerable<string> files)
         {
             var matchers = new List<PathMatchSet>
             {

--- a/BurnOutSharp/ProtectionType/DVDMoviePROTECT.cs
+++ b/BurnOutSharp/ProtectionType/DVDMoviePROTECT.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 
@@ -8,8 +9,10 @@ namespace BurnOutSharp.ProtectionType
     public class DVDMoviePROTECT : IPathCheck
     {
         /// <inheritdoc/>
-        public List<string> CheckDirectoryPath(string path, IEnumerable<string> files)
+        public ConcurrentQueue<string> CheckDirectoryPath(string path, IEnumerable<string> files)
         {
+            var protections = new ConcurrentQueue<string>();
+
             if (Directory.Exists(Path.Combine(path, "VIDEO_TS")))
             {
                 string[] bupfiles = files.Where(s => s.EndsWith(".bup")).ToArray();
@@ -18,11 +21,14 @@ namespace BurnOutSharp.ProtectionType
                     FileInfo bupfile = new FileInfo(bupfiles[i]);
                     FileInfo ifofile = new FileInfo(Path.Combine(bupfile.DirectoryName, bupfile.Name.Substring(0, bupfile.Name.Length - bupfile.Extension.Length) + ".ifo"));
                     if (bupfile.Length != ifofile.Length)
-                        return new List<string>() { "DVD-Movie-PROTECT" };
+                    {
+                        protections.Enqueue("DVD-Movie-PROTECT");
+                        break;
+                    }
                 }
             }
 
-            return null;
+            return protections;
         }
 
         /// <inheritdoc/>

--- a/BurnOutSharp/ProtectionType/DiscGuard.cs
+++ b/BurnOutSharp/ProtectionType/DiscGuard.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections.Concurrent;
+using System.Collections.Generic;
 using BurnOutSharp.Matching;
 
 namespace BurnOutSharp.ProtectionType
@@ -6,7 +7,7 @@ namespace BurnOutSharp.ProtectionType
     public class DiscGuard : IPathCheck
     {
         /// <inheritdoc/>
-        public List<string> CheckDirectoryPath(string path, IEnumerable<string> files)
+        public ConcurrentQueue<string> CheckDirectoryPath(string path, IEnumerable<string> files)
         {
             var matchers = new List<PathMatchSet>
             {

--- a/BurnOutSharp/ProtectionType/FreeLock.cs
+++ b/BurnOutSharp/ProtectionType/FreeLock.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections.Concurrent;
+using System.Collections.Generic;
 using BurnOutSharp.Matching;
 
 namespace BurnOutSharp.ProtectionType
@@ -6,7 +7,7 @@ namespace BurnOutSharp.ProtectionType
     public class FreeLock : IPathCheck
     {
         /// <inheritdoc/>
-        public List<string> CheckDirectoryPath(string path, IEnumerable<string> files)
+        public ConcurrentQueue<string> CheckDirectoryPath(string path, IEnumerable<string> files)
         {
             var matchers = new List<PathMatchSet>
             {

--- a/BurnOutSharp/ProtectionType/GFWL.cs
+++ b/BurnOutSharp/ProtectionType/GFWL.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections.Concurrent;
+using System.Collections.Generic;
 using BurnOutSharp.Matching;
 
 namespace BurnOutSharp.ProtectionType
@@ -18,7 +19,7 @@ namespace BurnOutSharp.ProtectionType
         }
 
         /// <inheritdoc/>
-        public List<string> CheckDirectoryPath(string path, IEnumerable<string> files)
+        public ConcurrentQueue<string> CheckDirectoryPath(string path, IEnumerable<string> files)
         {
             var matchers = new List<PathMatchSet>
             {

--- a/BurnOutSharp/ProtectionType/HexalockAutoLock.cs
+++ b/BurnOutSharp/ProtectionType/HexalockAutoLock.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections.Concurrent;
+using System.Collections.Generic;
 using BurnOutSharp.Matching;
 
 namespace BurnOutSharp.ProtectionType
@@ -6,7 +7,7 @@ namespace BurnOutSharp.ProtectionType
     public class HexalockAutoLock : IPathCheck
     {
         /// <inheritdoc/>
-        public List<string> CheckDirectoryPath(string path, IEnumerable<string> files)
+        public ConcurrentQueue<string> CheckDirectoryPath(string path, IEnumerable<string> files)
         {
             // TODO: Verify if these are OR or AND
             var matchers = new List<PathMatchSet>

--- a/BurnOutSharp/ProtectionType/ImpulseReactor.cs
+++ b/BurnOutSharp/ProtectionType/ImpulseReactor.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections.Concurrent;
+using System.Collections.Generic;
 using BurnOutSharp.Matching;
 
 namespace BurnOutSharp.ProtectionType
@@ -45,7 +46,7 @@ namespace BurnOutSharp.ProtectionType
         }
 
         /// <inheritdoc/>
-        public List<string> CheckDirectoryPath(string path, IEnumerable<string> files)
+        public ConcurrentQueue<string> CheckDirectoryPath(string path, IEnumerable<string> files)
         {
             var matchers = new List<PathMatchSet>
             {

--- a/BurnOutSharp/ProtectionType/IndyVCD.cs
+++ b/BurnOutSharp/ProtectionType/IndyVCD.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections.Concurrent;
+using System.Collections.Generic;
 using BurnOutSharp.Matching;
 
 namespace BurnOutSharp.ProtectionType
@@ -6,7 +7,7 @@ namespace BurnOutSharp.ProtectionType
     public class IndyVCD : IPathCheck
     {
         /// <inheritdoc/>
-        public List<string> CheckDirectoryPath(string path, IEnumerable<string> files)
+        public ConcurrentQueue<string> CheckDirectoryPath(string path, IEnumerable<string> files)
         {
             // TODO: Verify if these are OR or AND
             var matchers = new List<PathMatchSet>

--- a/BurnOutSharp/ProtectionType/Key2AudioXS.cs
+++ b/BurnOutSharp/ProtectionType/Key2AudioXS.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections.Concurrent;
+using System.Collections.Generic;
 using BurnOutSharp.Matching;
 
 namespace BurnOutSharp.ProtectionType
@@ -6,7 +7,7 @@ namespace BurnOutSharp.ProtectionType
     public class Key2AudioXS : IPathCheck
     {
         /// <inheritdoc/>
-        public List<string> CheckDirectoryPath(string path, IEnumerable<string> files)
+        public ConcurrentQueue<string> CheckDirectoryPath(string path, IEnumerable<string> files)
         {
             // TODO: Verify if these are OR or AND
             var matchers = new List<PathMatchSet>

--- a/BurnOutSharp/ProtectionType/LaserLock.cs
+++ b/BurnOutSharp/ProtectionType/LaserLock.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -62,7 +63,7 @@ namespace BurnOutSharp.ProtectionType
         }
 
         /// <inheritdoc/>
-        public List<string> CheckDirectoryPath(string path, IEnumerable<string> files)
+        public ConcurrentQueue<string> CheckDirectoryPath(string path, IEnumerable<string> files)
         {
             var matchers = new List<PathMatchSet>
             {

--- a/BurnOutSharp/ProtectionType/MediaCloQ.cs
+++ b/BurnOutSharp/ProtectionType/MediaCloQ.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections.Concurrent;
+using System.Collections.Generic;
 using BurnOutSharp.Matching;
 
 namespace BurnOutSharp.ProtectionType
@@ -6,7 +7,7 @@ namespace BurnOutSharp.ProtectionType
     public class MediaCloQ : IPathCheck
     {
         /// <inheritdoc/>
-        public List<string> CheckDirectoryPath(string path, IEnumerable<string> files)
+        public ConcurrentQueue<string> CheckDirectoryPath(string path, IEnumerable<string> files)
         {
             var matchers = new List<PathMatchSet>
             {

--- a/BurnOutSharp/ProtectionType/MediaMaxCD3.cs
+++ b/BurnOutSharp/ProtectionType/MediaMaxCD3.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections.Concurrent;
+using System.Collections.Generic;
 using BurnOutSharp.Matching;
 
 namespace BurnOutSharp.ProtectionType
@@ -25,7 +26,7 @@ namespace BurnOutSharp.ProtectionType
         }
 
         /// <inheritdoc/>
-        public List<string> CheckDirectoryPath(string path, IEnumerable<string> files)
+        public ConcurrentQueue<string> CheckDirectoryPath(string path, IEnumerable<string> files)
         {
             var matchers = new List<PathMatchSet>
             {

--- a/BurnOutSharp/ProtectionType/Origin.cs
+++ b/BurnOutSharp/ProtectionType/Origin.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using BurnOutSharp.Matching;
 
@@ -18,7 +19,7 @@ namespace BurnOutSharp.ProtectionType
         }
 
         /// <inheritdoc/>
-        public List<string> CheckDirectoryPath(string path, IEnumerable<string> files)
+        public ConcurrentQueue<string> CheckDirectoryPath(string path, IEnumerable<string> files)
         {
             var matchers = new List<PathMatchSet>
             {

--- a/BurnOutSharp/ProtectionType/ProtectDVDVideo.cs
+++ b/BurnOutSharp/ProtectionType/ProtectDVDVideo.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 
@@ -8,8 +9,10 @@ namespace BurnOutSharp.ProtectionType
     public class ProtectDVDVideo : IPathCheck
     {
         /// <inheritdoc/>
-        public List<string> CheckDirectoryPath(string path, IEnumerable<string> files)
+        public ConcurrentQueue<string> CheckDirectoryPath(string path, IEnumerable<string> files)
         {
+            var protections = new ConcurrentQueue<string>();
+
             if (Directory.Exists(Path.Combine(path, "VIDEO_TS")))
             {
                 string[] ifofiles = files.Where(s => s.EndsWith(".ifo")).ToArray();
@@ -17,11 +20,14 @@ namespace BurnOutSharp.ProtectionType
                 {
                     FileInfo ifofile = new FileInfo(ifofiles[i]);
                     if (ifofile.Length == 0)
-                        return new List<string>() { "Protect DVD-Video" };
+                    {
+                        protections.Enqueue("Protect DVD-Video");
+                        break;
+                    }
                 }
             }
             
-            return null;
+            return protections;
         }
 
         /// <inheritdoc/>

--- a/BurnOutSharp/ProtectionType/SafeCast.cs
+++ b/BurnOutSharp/ProtectionType/SafeCast.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections.Concurrent;
+using System.Collections.Generic;
 using BurnOutSharp.Matching;
 
 namespace BurnOutSharp.ProtectionType
@@ -6,7 +7,7 @@ namespace BurnOutSharp.ProtectionType
     public class SafeCast : IPathCheck
     {
         /// <inheritdoc/>
-        public List<string> CheckDirectoryPath(string path, IEnumerable<string> files)
+        public ConcurrentQueue<string> CheckDirectoryPath(string path, IEnumerable<string> files)
         {
             var matchers = new List<PathMatchSet>
             {

--- a/BurnOutSharp/ProtectionType/SafeDisc.cs
+++ b/BurnOutSharp/ProtectionType/SafeDisc.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -84,7 +85,7 @@ namespace BurnOutSharp.ProtectionType
         }
 
         /// <inheritdoc/>
-        public List<string> CheckDirectoryPath(string path, IEnumerable<string> files)
+        public ConcurrentQueue<string> CheckDirectoryPath(string path, IEnumerable<string> files)
         {
             return MatchUtil.GetAllMatches(files, pathMatchers, any: false);
         }

--- a/BurnOutSharp/ProtectionType/SafeDiscLite.cs
+++ b/BurnOutSharp/ProtectionType/SafeDiscLite.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections.Concurrent;
+using System.Collections.Generic;
 using BurnOutSharp.Matching;
 
 namespace BurnOutSharp.ProtectionType
@@ -6,7 +7,7 @@ namespace BurnOutSharp.ProtectionType
     public class SafeDiscLite : IPathCheck
     {
         /// <inheritdoc/>
-        public List<string> CheckDirectoryPath(string path, IEnumerable<string> files)
+        public ConcurrentQueue<string> CheckDirectoryPath(string path, IEnumerable<string> files)
         {
             var matchers = new List<PathMatchSet>
             {

--- a/BurnOutSharp/ProtectionType/SafeLock.cs
+++ b/BurnOutSharp/ProtectionType/SafeLock.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections.Concurrent;
+using System.Collections.Generic;
 using BurnOutSharp.Matching;
 
 namespace BurnOutSharp.ProtectionType
@@ -18,7 +19,7 @@ namespace BurnOutSharp.ProtectionType
         }
 
         /// <inheritdoc/>
-        public List<string> CheckDirectoryPath(string path, IEnumerable<string> files)
+        public ConcurrentQueue<string> CheckDirectoryPath(string path, IEnumerable<string> files)
         {
             // TODO: Verify if these are OR or AND
             var matchers = new List<PathMatchSet>

--- a/BurnOutSharp/ProtectionType/SecuROM.cs
+++ b/BurnOutSharp/ProtectionType/SecuROM.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Text;
 using BurnOutSharp.Matching;
@@ -56,7 +57,7 @@ namespace BurnOutSharp.ProtectionType
         }
 
         /// <inheritdoc/>
-        public List<string> CheckDirectoryPath(string path, IEnumerable<string> files)
+        public ConcurrentQueue<string> CheckDirectoryPath(string path, IEnumerable<string> files)
         {
             var matchers = new List<PathMatchSet>
             {

--- a/BurnOutSharp/ProtectionType/SmartE.cs
+++ b/BurnOutSharp/ProtectionType/SmartE.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.IO;
 using BurnOutSharp.Matching;
 
@@ -19,7 +20,7 @@ namespace BurnOutSharp.ProtectionType
         }
 
         /// <inheritdoc/>
-        public List<string> CheckDirectoryPath(string path, IEnumerable<string> files)
+        public ConcurrentQueue<string> CheckDirectoryPath(string path, IEnumerable<string> files)
         {
             // TODO: Verify if these are OR or AND
             var matchers = new List<PathMatchSet>

--- a/BurnOutSharp/ProtectionType/SoftLock.cs
+++ b/BurnOutSharp/ProtectionType/SoftLock.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections.Concurrent;
+using System.Collections.Generic;
 using BurnOutSharp.Matching;
 
 namespace BurnOutSharp.ProtectionType
@@ -6,7 +7,7 @@ namespace BurnOutSharp.ProtectionType
     public class SoftLock : IPathCheck
     {
         /// <inheritdoc/>
-        public List<string> CheckDirectoryPath(string path, IEnumerable<string> files)
+        public ConcurrentQueue<string> CheckDirectoryPath(string path, IEnumerable<string> files)
         {
             // TODO: Verify if these are OR or AND
             var matchers = new List<PathMatchSet>

--- a/BurnOutSharp/ProtectionType/SolidShield.cs
+++ b/BurnOutSharp/ProtectionType/SolidShield.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -94,7 +95,7 @@ namespace BurnOutSharp.ProtectionType
         }
 
         /// <inheritdoc/>
-        public List<string> CheckDirectoryPath(string path, IEnumerable<string> files)
+        public ConcurrentQueue<string> CheckDirectoryPath(string path, IEnumerable<string> files)
         {
             // TODO: Verify if these are OR or AND
             return MatchUtil.GetAllMatches(files, pathMatchers, any: true);

--- a/BurnOutSharp/ProtectionType/StarForce.cs
+++ b/BurnOutSharp/ProtectionType/StarForce.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Linq;
 using BurnOutSharp.Matching;
 
@@ -117,7 +118,7 @@ namespace BurnOutSharp.ProtectionType
         }
 
         /// <inheritdoc/>
-        public List<string> CheckDirectoryPath(string path, IEnumerable<string> files)
+        public ConcurrentQueue<string> CheckDirectoryPath(string path, IEnumerable<string> files)
         {
             var matchers = new List<PathMatchSet>
             {

--- a/BurnOutSharp/ProtectionType/Steam.cs
+++ b/BurnOutSharp/ProtectionType/Steam.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections.Concurrent;
+using System.Collections.Generic;
 using BurnOutSharp.Matching;
 
 namespace BurnOutSharp.ProtectionType
@@ -6,7 +7,7 @@ namespace BurnOutSharp.ProtectionType
     public class Steam : IPathCheck
     {
         /// <inheritdoc/>
-        public List<string> CheckDirectoryPath(string path, IEnumerable<string> files)
+        public ConcurrentQueue<string> CheckDirectoryPath(string path, IEnumerable<string> files)
         {
             var matchers = new List<PathMatchSet>
             {

--- a/BurnOutSharp/ProtectionType/TZCopyProtector.cs
+++ b/BurnOutSharp/ProtectionType/TZCopyProtector.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections.Concurrent;
+using System.Collections.Generic;
 using BurnOutSharp.Matching;
 
 namespace BurnOutSharp.ProtectionType
@@ -6,7 +7,7 @@ namespace BurnOutSharp.ProtectionType
     public class TZCopyProtector : IPathCheck
     {
         /// <inheritdoc/>
-        public List<string> CheckDirectoryPath(string path, IEnumerable<string> files)
+        public ConcurrentQueue<string> CheckDirectoryPath(string path, IEnumerable<string> files)
         {
             var matchers = new List<PathMatchSet>
             {

--- a/BurnOutSharp/ProtectionType/Tages.cs
+++ b/BurnOutSharp/ProtectionType/Tages.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -39,30 +40,30 @@ namespace BurnOutSharp.ProtectionType
         }
 
         /// <inheritdoc/>
-        public List<string> CheckDirectoryPath(string path, IEnumerable<string> files)
+        public ConcurrentQueue<string> CheckDirectoryPath(string path, IEnumerable<string> files)
         {
-            List<string> protections = new List<string>();
+            var protections = new ConcurrentQueue<string>();
 
             // TODO: Verify if these are OR or AND
             if (files.Any(f => Path.GetFileName(f).Equals("Tages.dll", StringComparison.OrdinalIgnoreCase))
                 || files.Any(f => Path.GetFileName(f).Equals("Wave.aif", StringComparison.OrdinalIgnoreCase)))
             {
-                protections.Add("TAGES");
+                protections.Enqueue("TAGES");
             }
             if (files.Any(f => Path.GetFileName(f).Equals("tagesclient.exe", StringComparison.OrdinalIgnoreCase)))
             {
                 string file = files.First(f => Path.GetFileName(f).Equals("tagesclient.exe", StringComparison.OrdinalIgnoreCase));
-                protections.Add("TAGES Activation Client " + Utilities.GetFileVersion(file));
+                protections.Enqueue("TAGES Activation Client " + Utilities.GetFileVersion(file));
             }
             if (files.Any(f => Path.GetFileName(f).Equals("TagesSetup.exe", StringComparison.OrdinalIgnoreCase)))
             {
                 string file = files.First(f => Path.GetFileName(f).Equals("TagesSetup.exe", StringComparison.OrdinalIgnoreCase));
-                protections.Add("TAGES Setup " + Utilities.GetFileVersion(file));
+                protections.Enqueue("TAGES Setup " + Utilities.GetFileVersion(file));
             }
             if (files.Any(f => Path.GetFileName(f).Equals("TagesSetup_x64.exe", StringComparison.OrdinalIgnoreCase)))
             {
                 string file = files.First(f => Path.GetFileName(f).Equals("TagesSetup_x64.exe", StringComparison.OrdinalIgnoreCase));
-                protections.Add("TAGES Setup " + Utilities.GetFileVersion(file));
+                protections.Enqueue("TAGES Setup " + Utilities.GetFileVersion(file));
             }
 
             if (protections.Count == 0)

--- a/BurnOutSharp/ProtectionType/TivolaRingProtection.cs
+++ b/BurnOutSharp/ProtectionType/TivolaRingProtection.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.IO;
 using BurnOutSharp.Matching;
 
@@ -10,7 +11,7 @@ namespace BurnOutSharp.ProtectionType
     public class TivolaRingProtection : IPathCheck
     {
         /// <inheritdoc/>
-        public List<string> CheckDirectoryPath(string path, IEnumerable<string> files)
+        public ConcurrentQueue<string> CheckDirectoryPath(string path, IEnumerable<string> files)
         {
             var matchers = new List<PathMatchSet>
             {

--- a/BurnOutSharp/ProtectionType/Uplay.cs
+++ b/BurnOutSharp/ProtectionType/Uplay.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections.Concurrent;
+using System.Collections.Generic;
 using BurnOutSharp.Matching;
 
 namespace BurnOutSharp.ProtectionType
@@ -6,7 +7,7 @@ namespace BurnOutSharp.ProtectionType
     public class Uplay : IPathCheck
     {
         /// <inheritdoc/>
-        public List<string> CheckDirectoryPath(string path, IEnumerable<string> files)
+        public ConcurrentQueue<string> CheckDirectoryPath(string path, IEnumerable<string> files)
         {
             var matchers = new List<PathMatchSet>
             {

--- a/BurnOutSharp/ProtectionType/VOBProtectCDDVD.cs
+++ b/BurnOutSharp/ProtectionType/VOBProtectCDDVD.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -33,7 +34,7 @@ namespace BurnOutSharp.ProtectionType
         }
 
         /// <inheritdoc/>
-        public List<string> CheckDirectoryPath(string path, IEnumerable<string> files)
+        public ConcurrentQueue<string> CheckDirectoryPath(string path, IEnumerable<string> files)
         {
             var matchers = new List<PathMatchSet>
             {

--- a/BurnOutSharp/ProtectionType/WTMCDProtect.cs
+++ b/BurnOutSharp/ProtectionType/WTMCDProtect.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections.Concurrent;
+using System.Collections.Generic;
 using BurnOutSharp.Matching;
 
 namespace BurnOutSharp.ProtectionType
@@ -38,7 +39,7 @@ namespace BurnOutSharp.ProtectionType
         }
 
         /// <inheritdoc/>
-        public List<string> CheckDirectoryPath(string path, IEnumerable<string> files)
+        public ConcurrentQueue<string> CheckDirectoryPath(string path, IEnumerable<string> files)
         {
             var matchers = new List<PathMatchSet>
             {

--- a/BurnOutSharp/ProtectionType/Winlock.cs
+++ b/BurnOutSharp/ProtectionType/Winlock.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections.Concurrent;
+using System.Collections.Generic;
 using BurnOutSharp.Matching;
 
 namespace BurnOutSharp.ProtectionType
@@ -6,7 +7,7 @@ namespace BurnOutSharp.ProtectionType
     public class Winlock : IPathCheck
     {
         /// <inheritdoc/>
-        public List<string> CheckDirectoryPath(string path, IEnumerable<string> files)
+        public ConcurrentQueue<string> CheckDirectoryPath(string path, IEnumerable<string> files)
         {
             var matchers = new List<PathMatchSet>
             {

--- a/BurnOutSharp/ProtectionType/XCP.cs
+++ b/BurnOutSharp/ProtectionType/XCP.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -46,8 +47,10 @@ namespace BurnOutSharp.ProtectionType
         }
 
         /// <inheritdoc/>
-        public List<string> CheckDirectoryPath(string path, IEnumerable<string> files)
+        public ConcurrentQueue<string> CheckDirectoryPath(string path, IEnumerable<string> files)
         {
+            var protections = new ConcurrentQueue<string>();
+
             // TODO: Verify if these are OR or AND
             if (files.Any(f => Path.GetFileName(f).Equals("XCP.DAT", StringComparison.OrdinalIgnoreCase))
                 || files.Any(f => Path.GetFileName(f).Equals("ECDPlayerControl.ocx", StringComparison.OrdinalIgnoreCase)))
@@ -57,13 +60,15 @@ namespace BurnOutSharp.ProtectionType
                 {
                     string xcpVersion = GetDatVersion(versionDatPath);
                     if (!string.IsNullOrWhiteSpace(xcpVersion))
-                        return new List<string>() { xcpVersion };
+                        protections.Enqueue(xcpVersion);
                 }
-
-                return new List<string>() { "XCP" };
+                else
+                {
+                    protections.Enqueue("XCP");
+                }
             }
 
-            return null;
+            return protections;
         }
 
         /// <inheritdoc/>

--- a/BurnOutSharp/ProtectionType/Zzxzz.cs
+++ b/BurnOutSharp/ProtectionType/Zzxzz.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using BurnOutSharp.Matching;
@@ -7,7 +8,7 @@ namespace BurnOutSharp.ProtectionType
     public class Zzxzz : IPathCheck
     {
         /// <inheritdoc/>
-        public List<string> CheckDirectoryPath(string path, IEnumerable<string> files)
+        public ConcurrentQueue<string> CheckDirectoryPath(string path, IEnumerable<string> files)
         {
             var matchers = new List<PathMatchSet>
             {

--- a/BurnOutSharp/Scanner.cs
+++ b/BurnOutSharp/Scanner.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -54,7 +55,7 @@ namespace BurnOutSharp
         /// </summary>
         /// <param name="path">Path to scan</param>
         /// <returns>Dictionary of list of strings representing the found protections</returns>
-        public Dictionary<string, List<string>> GetProtections(string path)
+        public ConcurrentDictionary<string, List<string>> GetProtections(string path)
         {
             return GetProtections(new List<string> { path });
         }
@@ -63,7 +64,7 @@ namespace BurnOutSharp
         /// Scan the list of paths and get all found protections
         /// </summary>
         /// <returns>Dictionary of list of strings representing the found protections</returns>
-        public Dictionary<string, List<string>> GetProtections(List<string> paths)
+        public ConcurrentDictionary<string, List<string>> GetProtections(List<string> paths)
         {
             // If we have no paths, we can't scan
             if (paths == null || !paths.Any())
@@ -77,7 +78,7 @@ namespace BurnOutSharp
             string tempFilePathWithGuid = Path.Combine(tempFilePath, Guid.NewGuid().ToString());
 
             // Loop through each path and get the returned values
-            var protections = new Dictionary<string, List<string>>();
+            var protections = new ConcurrentDictionary<string, List<string>>();
             foreach (string path in paths)
             {
                 // Directories scan each internal file individually
@@ -182,7 +183,7 @@ namespace BurnOutSharp
         /// <param name="path">Path of the directory to scan</param>
         /// <param name="files">Files contained within</param>
         /// <returns>Dictionary of list of strings representing the found protections</returns>
-        private Dictionary<string, List<string>> GetDirectoryPathProtections(string path, List<string> files)
+        private ConcurrentDictionary<string, List<string>> GetDirectoryPathProtections(string path, List<string> files)
         {
             // Create an empty list for protections
             List<string> protections = new List<string>();
@@ -199,7 +200,7 @@ namespace BurnOutSharp
             }
 
             // Create and return the dictionary
-            return new Dictionary<string, List<string>>
+            return new ConcurrentDictionary<string, List<string>>
             {
                 [path] = protections
             };
@@ -210,7 +211,7 @@ namespace BurnOutSharp
         /// </summary>
         /// <param name="path">Path of the file to scan</param>
         /// <returns>Dictionary of list of strings representing the found protections</returns>
-        private Dictionary<string, List<string>> GetFilePathProtections(string path)
+        private ConcurrentDictionary<string, List<string>> GetFilePathProtections(string path)
         {
             // Create an empty list for protections
             List<string> protections = new List<string>();
@@ -224,7 +225,7 @@ namespace BurnOutSharp
             }
 
             // Create and return the dictionary
-            return new Dictionary<string, List<string>>
+            return new ConcurrentDictionary<string, List<string>>
             {
                 [path] = protections
             };
@@ -235,14 +236,14 @@ namespace BurnOutSharp
         /// </summary>
         /// <param name="file">Path to the file to scan</param>
         /// <returns>Dictionary of list of strings representing the found protections</returns>
-        private Dictionary<string, List<string>> GetInternalProtections(string file)
+        private ConcurrentDictionary<string, List<string>> GetInternalProtections(string file)
         {
             // Quick sanity check before continuing
             if (!File.Exists(file))
                 return null;
 
             // Initialze the protections found
-            var protections = new Dictionary<string, List<string>>();
+            var protections = new ConcurrentDictionary<string, List<string>>();
 
             // Get the extension for certain checks
             string extension = Path.GetExtension(file).ToLower().TrimStart('.');

--- a/BurnOutSharp/Scanner.cs
+++ b/BurnOutSharp/Scanner.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Threading.Tasks;
 using BurnOutSharp.FileType;
 
 namespace BurnOutSharp
@@ -55,7 +56,7 @@ namespace BurnOutSharp
         /// </summary>
         /// <param name="path">Path to scan</param>
         /// <returns>Dictionary of list of strings representing the found protections</returns>
-        public ConcurrentDictionary<string, List<string>> GetProtections(string path)
+        public ConcurrentDictionary<string, ConcurrentQueue<string>> GetProtections(string path)
         {
             return GetProtections(new List<string> { path });
         }
@@ -64,7 +65,7 @@ namespace BurnOutSharp
         /// Scan the list of paths and get all found protections
         /// </summary>
         /// <returns>Dictionary of list of strings representing the found protections</returns>
-        public ConcurrentDictionary<string, List<string>> GetProtections(List<string> paths)
+        public ConcurrentDictionary<string, ConcurrentQueue<string>> GetProtections(List<string> paths)
         {
             // If we have no paths, we can't scan
             if (paths == null || !paths.Any())
@@ -78,7 +79,7 @@ namespace BurnOutSharp
             string tempFilePathWithGuid = Path.Combine(tempFilePath, Guid.NewGuid().ToString());
 
             // Loop through each path and get the returned values
-            var protections = new ConcurrentDictionary<string, List<string>>();
+            var protections = new ConcurrentDictionary<string, ConcurrentQueue<string>>();
             foreach (string path in paths)
             {
                 // Directories scan each internal file individually
@@ -116,14 +117,14 @@ namespace BurnOutSharp
                             foreach (string key in fileProtections.Keys)
                             {
                                 if (!protections.ContainsKey(key))
-                                    protections[key] = new List<string>();
+                                    protections[key] = new ConcurrentQueue<string>();
 
                                 protections[key].AddRange(fileProtections[key]);
                             }
                         }
 
                         // Checkpoint
-                        protections.TryGetValue(file, out List<string> fullProtectionList);
+                        protections.TryGetValue(file, out ConcurrentQueue<string> fullProtectionList);
                         string fullProtection = (fullProtectionList != null && fullProtectionList.Any() ? string.Join(", ", fullProtectionList) : null);
                         FileProgress?.Report(new ProtectionProgress(reportableFileName, (i + 1) / (float)files.Count, fullProtection ?? string.Empty));
                     }
@@ -151,14 +152,14 @@ namespace BurnOutSharp
                         foreach (string key in fileProtections.Keys)
                         {
                             if (!protections.ContainsKey(key))
-                                protections[key] = new List<string>();
+                                protections[key] = new ConcurrentQueue<string>();
 
                             protections[key].AddRange(fileProtections[key]);
                         }
                     }
 
                     // Checkpoint
-                    protections.TryGetValue(path, out List<string> fullProtectionList);
+                    protections.TryGetValue(path, out ConcurrentQueue<string> fullProtectionList);
                     string fullProtection = (fullProtectionList != null && fullProtectionList.Any() ? string.Join(", ", fullProtectionList) : null);
                     FileProgress?.Report(new ProtectionProgress(reportableFileName, 1, fullProtection ?? string.Empty));
                 }
@@ -183,24 +184,24 @@ namespace BurnOutSharp
         /// <param name="path">Path of the directory to scan</param>
         /// <param name="files">Files contained within</param>
         /// <returns>Dictionary of list of strings representing the found protections</returns>
-        private ConcurrentDictionary<string, List<string>> GetDirectoryPathProtections(string path, List<string> files)
+        private ConcurrentDictionary<string, ConcurrentQueue<string>> GetDirectoryPathProtections(string path, List<string> files)
         {
-            // Create an empty list for protections
-            List<string> protections = new List<string>();
+            // Create an empty queue for protections
+            var protections = new ConcurrentQueue<string>();
 
             // Preprocess the list of files
             files = files.Select(f => f.Replace('\\', '/')).ToList();
 
             // Iterate through all path checks
-            foreach (var pathCheckClass in pathCheckClasses)
+            Parallel.ForEach(pathCheckClasses, pathCheckClass =>
             {
-                List<string> protection = pathCheckClass.CheckDirectoryPath(path, files);
+                ConcurrentQueue<string> protection = pathCheckClass.CheckDirectoryPath(path, files);
                 if (protection != null)
                     protections.AddRange(protection);
-            }
+            });
 
             // Create and return the dictionary
-            return new ConcurrentDictionary<string, List<string>>
+            return new ConcurrentDictionary<string, ConcurrentQueue<string>>
             {
                 [path] = protections
             };
@@ -211,21 +212,21 @@ namespace BurnOutSharp
         /// </summary>
         /// <param name="path">Path of the file to scan</param>
         /// <returns>Dictionary of list of strings representing the found protections</returns>
-        private ConcurrentDictionary<string, List<string>> GetFilePathProtections(string path)
+        private ConcurrentDictionary<string, ConcurrentQueue<string>> GetFilePathProtections(string path)
         {
-            // Create an empty list for protections
-            List<string> protections = new List<string>();
+            // Create an empty queue for protections
+            var protections = new ConcurrentQueue<string>();
 
             // Iterate through all path checks
-            foreach (var pathCheckClass in pathCheckClasses)
+            Parallel.ForEach(pathCheckClasses, pathCheckClass =>
             {
                 string protection = pathCheckClass.CheckFilePath(path.Replace("\\", "/"));
                 if (!string.IsNullOrWhiteSpace(protection))
-                    protections.Add(protection);
-            }
+                    protections.Enqueue(protection);
+            });
 
             // Create and return the dictionary
-            return new ConcurrentDictionary<string, List<string>>
+            return new ConcurrentDictionary<string, ConcurrentQueue<string>>
             {
                 [path] = protections
             };
@@ -236,14 +237,14 @@ namespace BurnOutSharp
         /// </summary>
         /// <param name="file">Path to the file to scan</param>
         /// <returns>Dictionary of list of strings representing the found protections</returns>
-        private ConcurrentDictionary<string, List<string>> GetInternalProtections(string file)
+        private ConcurrentDictionary<string, ConcurrentQueue<string>> GetInternalProtections(string file)
         {
             // Quick sanity check before continuing
             if (!File.Exists(file))
                 return null;
 
             // Initialze the protections found
-            var protections = new ConcurrentDictionary<string, List<string>>();
+            var protections = new ConcurrentDictionary<string, ConcurrentQueue<string>>();
 
             // Get the extension for certain checks
             string extension = Path.GetExtension(file).ToLower().TrimStart('.');

--- a/BurnOutSharp/Utilities.cs
+++ b/BurnOutSharp/Utilities.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -19,7 +20,7 @@ namespace BurnOutSharp
         /// <param name="original">Dictionary to append to</param>
         /// <param name="key">Key to add information to</param>
         /// <param name="value">String value to add</param>
-        public static void AppendToDictionary(Dictionary<string, List<string>> original, string key, string value)
+        public static void AppendToDictionary(ConcurrentDictionary<string, List<string>> original, string key, string value)
         {
             AppendToDictionary(original, key, new List<string> { value });
         }
@@ -30,7 +31,7 @@ namespace BurnOutSharp
         /// <param name="original">Dictionary to append to</param>
         /// <param name="key">Key to add information to</param>
         /// <param name="value">String value to add</param>
-        public static void AppendToDictionary(Dictionary<string, List<string>> original, string key, List<string> values)
+        public static void AppendToDictionary(ConcurrentDictionary<string, List<string>> original, string key, List<string> values)
         {
             // If the dictionary is null, just return
             if (original == null)
@@ -40,9 +41,7 @@ namespace BurnOutSharp
             key = key ?? "NO FILENAME";
 
             // Add the key if needed and then append the lists
-            if (!original.ContainsKey(key))
-                original[key] = new List<string>();
-
+            original.TryAdd(key, new List<string>());
             original[key].AddRange(values);
         }
 
@@ -51,7 +50,7 @@ namespace BurnOutSharp
         /// </summary>
         /// <param name="original">Dictionary to append to</param>
         /// <param name="addition">Dictionary to pull from</param>
-        public static void AppendToDictionary(Dictionary<string, List<string>> original, Dictionary<string, List<string>> addition)
+        public static void AppendToDictionary(ConcurrentDictionary<string, List<string>> original, ConcurrentDictionary<string, List<string>> addition)
         {
             // If either dictionary is missing, just return
             if (original == null || addition == null)
@@ -60,9 +59,7 @@ namespace BurnOutSharp
             // Loop through each of the addition keys and add accordingly
             foreach (string key in addition.Keys)
             {
-                if (!original.ContainsKey(key))
-                    original[key] = new List<string>();
-
+                original.TryAdd(key, new List<string>());
                 original[key].AddRange(addition[key]);
             }
         }
@@ -71,7 +68,7 @@ namespace BurnOutSharp
         /// Remove empty or null keys from a results dictionary
         /// </summary>
         /// <param name="original">Dictionary to clean</param>
-        public static void ClearEmptyKeys(Dictionary<string, List<string>> original)
+        public static void ClearEmptyKeys(ConcurrentDictionary<string, List<string>> original)
         {
             // If the dictionary is missing, we can't do anything
             if (original == null)
@@ -88,7 +85,7 @@ namespace BurnOutSharp
 
                 // If the key is empty, remove it
                 if (original[key] == null || !original[key].Any())
-                    original.Remove(key);
+                    original.TryRemove(key, out _);
             }
         }
 
@@ -97,7 +94,7 @@ namespace BurnOutSharp
         /// </summary>
         /// <param name="original">Dictionary to strip values from</param>
         /// <param name="pathToPrepend">Path to strip from the keys</param>
-        public static void PrependToKeys(Dictionary<string, List<string>> original, string pathToPrepend)
+        public static void PrependToKeys(ConcurrentDictionary<string, List<string>> original, string pathToPrepend)
         {
             // If the dictionary is missing, we can't do anything
             if (original == null)
@@ -118,7 +115,7 @@ namespace BurnOutSharp
                 // Otherwise, get the new key name and transfer over
                 string newKey = $"{pathToPrepend}{Path.DirectorySeparatorChar}{currentKey.Trim(Path.DirectorySeparatorChar)}";
                 original[newKey] = original[currentKey];
-                original.Remove(currentKey);
+                original.TryRemove(currentKey, out _);
             }
         }
 
@@ -127,7 +124,7 @@ namespace BurnOutSharp
         /// </summary>
         /// <param name="original">Dictionary to strip values from</param>
         /// <param name="pathToStrip">Path to strip from the keys</param>
-        public static void StripFromKeys(Dictionary<string, List<string>> original, string pathToStrip)
+        public static void StripFromKeys(ConcurrentDictionary<string, List<string>> original, string pathToStrip)
         {
             // If either is missing, we can't do anything
             if (original == null || string.IsNullOrEmpty(pathToStrip))
@@ -149,7 +146,7 @@ namespace BurnOutSharp
                 // Otherwise, get the new key name and transfer over
                 string newKey = currentKey.Substring(pathToStrip.Length);
                 original[newKey] = original[currentKey];
-                original.Remove(currentKey);
+                original.TryRemove(currentKey, out _);
             }
         }
 

--- a/BurnOutSharp/Utilities.cs
+++ b/BurnOutSharp/Utilities.cs
@@ -20,9 +20,11 @@ namespace BurnOutSharp
         /// <param name="original">Dictionary to append to</param>
         /// <param name="key">Key to add information to</param>
         /// <param name="value">String value to add</param>
-        public static void AppendToDictionary(ConcurrentDictionary<string, List<string>> original, string key, string value)
+        public static void AppendToDictionary(ConcurrentDictionary<string, ConcurrentQueue<string>> original, string key, string value)
         {
-            AppendToDictionary(original, key, new List<string> { value });
+            var values = new ConcurrentQueue<string>();
+            values.Enqueue(value);
+            AppendToDictionary(original, key, values);
         }
 
         /// <summary>
@@ -31,7 +33,7 @@ namespace BurnOutSharp
         /// <param name="original">Dictionary to append to</param>
         /// <param name="key">Key to add information to</param>
         /// <param name="value">String value to add</param>
-        public static void AppendToDictionary(ConcurrentDictionary<string, List<string>> original, string key, List<string> values)
+        public static void AppendToDictionary(ConcurrentDictionary<string, ConcurrentQueue<string>> original, string key, ConcurrentQueue<string> values)
         {
             // If the dictionary is null, just return
             if (original == null)
@@ -41,7 +43,7 @@ namespace BurnOutSharp
             key = key ?? "NO FILENAME";
 
             // Add the key if needed and then append the lists
-            original.TryAdd(key, new List<string>());
+            original.TryAdd(key, new ConcurrentQueue<string>());
             original[key].AddRange(values);
         }
 
@@ -50,7 +52,7 @@ namespace BurnOutSharp
         /// </summary>
         /// <param name="original">Dictionary to append to</param>
         /// <param name="addition">Dictionary to pull from</param>
-        public static void AppendToDictionary(ConcurrentDictionary<string, List<string>> original, ConcurrentDictionary<string, List<string>> addition)
+        public static void AppendToDictionary(ConcurrentDictionary<string, ConcurrentQueue<string>> original, ConcurrentDictionary<string, ConcurrentQueue<string>> addition)
         {
             // If either dictionary is missing, just return
             if (original == null || addition == null)
@@ -59,7 +61,7 @@ namespace BurnOutSharp
             // Loop through each of the addition keys and add accordingly
             foreach (string key in addition.Keys)
             {
-                original.TryAdd(key, new List<string>());
+                original.TryAdd(key, new ConcurrentQueue<string>());
                 original[key].AddRange(addition[key]);
             }
         }
@@ -68,7 +70,7 @@ namespace BurnOutSharp
         /// Remove empty or null keys from a results dictionary
         /// </summary>
         /// <param name="original">Dictionary to clean</param>
-        public static void ClearEmptyKeys(ConcurrentDictionary<string, List<string>> original)
+        public static void ClearEmptyKeys(ConcurrentDictionary<string, ConcurrentQueue<string>> original)
         {
             // If the dictionary is missing, we can't do anything
             if (original == null)
@@ -94,7 +96,7 @@ namespace BurnOutSharp
         /// </summary>
         /// <param name="original">Dictionary to strip values from</param>
         /// <param name="pathToPrepend">Path to strip from the keys</param>
-        public static void PrependToKeys(ConcurrentDictionary<string, List<string>> original, string pathToPrepend)
+        public static void PrependToKeys(ConcurrentDictionary<string, ConcurrentQueue<string>> original, string pathToPrepend)
         {
             // If the dictionary is missing, we can't do anything
             if (original == null)
@@ -124,7 +126,7 @@ namespace BurnOutSharp
         /// </summary>
         /// <param name="original">Dictionary to strip values from</param>
         /// <param name="pathToStrip">Path to strip from the keys</param>
-        public static void StripFromKeys(ConcurrentDictionary<string, List<string>> original, string pathToStrip)
+        public static void StripFromKeys(ConcurrentDictionary<string, ConcurrentQueue<string>> original, string pathToStrip)
         {
             // If either is missing, we can't do anything
             if (original == null || string.IsNullOrEmpty(pathToStrip))
@@ -147,6 +149,26 @@ namespace BurnOutSharp
                 string newKey = currentKey.Substring(pathToStrip.Length);
                 original[newKey] = original[currentKey];
                 original.TryRemove(currentKey, out _);
+            }
+        }
+
+        #endregion
+
+        #region Concurrent Manipulation
+
+        /// <summary>
+        /// Add a range of values from one queue to another
+        /// </summary>
+        /// <param name="original">Queue to add data to</param>
+        /// <param name="values">Queue to get data from</param>
+        public static void AddRange(this ConcurrentQueue<string> original, ConcurrentQueue<string> values)
+        {
+            while (!values.IsEmpty)
+            {
+                if (!values.TryDequeue(out string value))
+                    return;
+
+                original.Enqueue(value);
             }
         }
 

--- a/Test/Program.cs
+++ b/Test/Program.cs
@@ -67,7 +67,7 @@ namespace Test
         /// </summary>
         /// <param name="path">File or directory path</param>
         /// <param name="protections">Dictionary of protections found, if any</param>
-        private static void WriteProtectionResultFile(string path, ConcurrentDictionary<string, List<string>> protections)
+        private static void WriteProtectionResultFile(string path, ConcurrentDictionary<string, ConcurrentQueue<string>> protections)
         {
             if (protections == null)
             {
@@ -77,13 +77,13 @@ namespace Test
 
             using (var sw = new StreamWriter(File.OpenWrite($"{DateTime.Now:yyyy-MM-dd_HHmmss}.txt")))
             {
-                foreach (string key in protections.Keys)
+                foreach (string key in protections.Keys.OrderBy(k => k))
                 {
                     // Skip over files with no protection
                     if (protections[key] == null || !protections[key].Any())
                         continue;
 
-                    string line = $"{key}: {string.Join(", ", protections[key])}";
+                    string line = $"{key}: {string.Join(", ", protections[key].OrderBy(p => p))}";
                     Console.WriteLine(line);
                     sw.WriteLine(line);
                 }

--- a/Test/Program.cs
+++ b/Test/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -66,7 +67,7 @@ namespace Test
         /// </summary>
         /// <param name="path">File or directory path</param>
         /// <param name="protections">Dictionary of protections found, if any</param>
-        private static void WriteProtectionResultFile(string path, Dictionary<string, List<string>> protections)
+        private static void WriteProtectionResultFile(string path, ConcurrentDictionary<string, List<string>> protections)
         {
             if (protections == null)
             {


### PR DESCRIPTION
This PR allows for multiple content and protection scans to be run per file without the risk of losing data. This fixes the slowness regression introduced by the last commit.

Fixes #52 