### PR TITLE
Refactor Setup Factory detection

### DIFF
--- a/BurnOutSharp/PackerType/SetupFactory.cs
+++ b/BurnOutSharp/PackerType/SetupFactory.cs
@@ -18,6 +18,7 @@ namespace BurnOutSharp.PackerType
             var sections = pex?.SectionTable;
             if (sections == null)
                 return null;
+
             // Known to detect versions 7.0.5.1 - 9.1.0.0
             string name = Utilities.GetLegalCopyright(pex);
             if (!string.IsNullOrWhiteSpace(name) && name.StartsWith("Setup Engine", StringComparison.OrdinalIgnoreCase))
@@ -64,7 +65,12 @@ namespace BurnOutSharp.PackerType
             string version = Utilities.GetProductVersion(pex);
             if (!string.IsNullOrEmpty(version))
                 return version;
-            
+
+            // Then check the file version
+            version = Utilities.GetFileVersion(pex);
+            if (!string.IsNullOrEmpty(version))
+                return version;
+
             // Then check the manifest version
             version = Utilities.GetManifestVersion(pex);
             if (!string.IsNullOrEmpty(version))

--- a/BurnOutSharp/PackerType/SetupFactory.cs
+++ b/BurnOutSharp/PackerType/SetupFactory.cs
@@ -18,12 +18,17 @@ namespace BurnOutSharp.PackerType
             var sections = pex?.SectionTable;
             if (sections == null)
                 return null;
-
+            // Known to detect versions 7.0.5.1 - 9.1.0.0
             string name = Utilities.GetLegalCopyright(pex);
-            if (!string.IsNullOrWhiteSpace(name) && name.StartsWith("Setup Factory", StringComparison.OrdinalIgnoreCase))
+            if (!string.IsNullOrWhiteSpace(name) && name.StartsWith("Setup Engine", StringComparison.OrdinalIgnoreCase))
                 return $"Setup Factory {GetVersion(pex)}";
 
             name = Utilities.GetProductName(pex);
+            if (!string.IsNullOrWhiteSpace(name) && name.StartsWith("Setup Factory", StringComparison.OrdinalIgnoreCase))
+                return $"Setup Factory {GetVersion(pex)}";
+
+            // Known to detect version 5.0.1 - 6.0.1.3
+            name = Utilities.GetFileDescription(pex);
             if (!string.IsNullOrWhiteSpace(name) && name.StartsWith("Setup Factory", StringComparison.OrdinalIgnoreCase))
                 return $"Setup Factory {GetVersion(pex)}";
 
@@ -55,13 +60,13 @@ namespace BurnOutSharp.PackerType
     
         private string GetVersion(PortableExecutable pex)
         {
-            // Check the manifest version first
-            string version = Utilities.GetManifestVersion(pex);
+            // Check the product version first
+            string version = Utilities.GetProductVersion(pex);
             if (!string.IsNullOrEmpty(version))
                 return version;
             
-            // Then check the file version
-            version = Utilities.GetFileVersion(pex);
+            // Then check the manifest version
+            version = Utilities.GetManifestVersion(pex);
             if (!string.IsNullOrEmpty(version))
                 return version;
 

--- a/BurnOutSharp/Tools/Utilities.cs
+++ b/BurnOutSharp/Tools/Utilities.cs
@@ -365,7 +365,7 @@ namespace BurnOutSharp.Tools
         /// <param name="pex">PortableExecutable representing the file contents</param>
         /// <returns>Product name string, null on error</returns>
         public static string GetProductName(PortableExecutable pex) => GetResourceString(pex, "ProductName");
-		
+
 		/// <summary>
         /// Get the product name as reported by the filesystem
         /// </summary>

--- a/BurnOutSharp/Tools/Utilities.cs
+++ b/BurnOutSharp/Tools/Utilities.cs
@@ -366,7 +366,7 @@ namespace BurnOutSharp.Tools
         /// <returns>Product name string, null on error</returns>
         public static string GetProductName(PortableExecutable pex) => GetResourceString(pex, "ProductName");
 
-		/// <summary>
+        /// <summary>
         /// Get the product name as reported by the filesystem
         /// </summary>
         /// <param name="pex">PortableExecutable representing the file contents</param>

--- a/BurnOutSharp/Tools/Utilities.cs
+++ b/BurnOutSharp/Tools/Utilities.cs
@@ -237,9 +237,9 @@ namespace BurnOutSharp.Tools
             if (!string.IsNullOrWhiteSpace(version))
                 return version.Replace(", ", ".");
 
-            version = GetResourceString(pex, "ProductVersion");
+            version = GetProductVersion(pex);
             if (!string.IsNullOrWhiteSpace(version))
-                return version.Replace(", ", ".");
+                return version;
 
             return null;
         }
@@ -365,6 +365,13 @@ namespace BurnOutSharp.Tools
         /// <param name="pex">PortableExecutable representing the file contents</param>
         /// <returns>Product name string, null on error</returns>
         public static string GetProductName(PortableExecutable pex) => GetResourceString(pex, "ProductName");
+		
+		/// <summary>
+        /// Get the product name as reported by the filesystem
+        /// </summary>
+        /// <param name="pex">PortableExecutable representing the file contents</param>
+        /// <returns>Product version string, null on error</returns>
+        public static string GetProductVersion(PortableExecutable pex) => GetResourceString(pex, "ProductVersion")?.Replace(", ", ".");
 
         /// <summary>
         /// Find resource data in a ResourceSection, if possible


### PR DESCRIPTION
Fix a broken Setup Factory check, add a new check that works for older versions, and add a new method to grab the product version, which is needed to accurately grab some Setup Factory versions.