### PR TITLE
Add notes to unconfirmed detections

### DIFF
--- a/BurnOutSharp/ProtectionType/ActiveMARK.cs
+++ b/BurnOutSharp/ProtectionType/ActiveMARK.cs
@@ -22,7 +22,7 @@ namespace BurnOutSharp.ProtectionType
                         0x20, 0xC2, 0x16, 0x00, 0xA8, 0xC1, 0x16, 0x00,
                         0xB8, 0xC1, 0x16, 0x00, 0x86, 0xC8, 0x16, 0x00,
                         0x9A, 0xC1, 0x16, 0x00, 0x10, 0xC2, 0x16, 0x00
-                    }, "ActiveMARK 5"),
+                    }, "ActiveMARK 5 (Unconfirmed - Please report to us on Github)"),
                 };
 
                 return MatchUtil.GetFirstMatch(file, fileContent, contentMatchSets, includeDebug);
@@ -44,6 +44,7 @@ namespace BurnOutSharp.ProtectionType
             {
                 var matchers = new List<ContentMatchSet>
                 {
+                    // Checks sourced from https://raw.githubusercontent.com/wolfram77web/app-peid/master/userdb.txt
                     new ContentMatchSet(new byte?[]
                     {
                         0x79, 0x11, 0x7F, 0xAB, 0x9A, 0x4A, 0x83, 0xB5,

--- a/BurnOutSharp/ProtectionType/AlphaDVD.cs
+++ b/BurnOutSharp/ProtectionType/AlphaDVD.cs
@@ -20,7 +20,7 @@ namespace BurnOutSharp.ProtectionType
         {
             var matchers = new List<PathMatchSet>
             {
-                new PathMatchSet(new PathMatch("PlayDVD.exe", useEndsWith: true), "Alpha-DVD"),
+                new PathMatchSet(new PathMatch("PlayDVD.exe", useEndsWith: true), "Alpha-DVD (Unconfirmed - Please report to us on Github)"),
             };
 
             return MatchUtil.GetAllMatches(files, matchers, any: true);
@@ -31,7 +31,7 @@ namespace BurnOutSharp.ProtectionType
         {
             var matchers = new List<PathMatchSet>
             {
-                new PathMatchSet(new PathMatch("PlayDVD.exe", useEndsWith: true), "Alpha-DVD"),
+                new PathMatchSet(new PathMatch("PlayDVD.exe", useEndsWith: true), "Alpha-DVD (Unconfirmed - Please report to us on Github"),
             };
 
             return MatchUtil.GetFirstMatch(path, matchers, any: true);

--- a/BurnOutSharp/ProtectionType/AlphaROM.cs
+++ b/BurnOutSharp/ProtectionType/AlphaROM.cs
@@ -60,9 +60,11 @@ namespace BurnOutSharp.ProtectionType
                 var matchers = new List<ContentMatchSet>
                 {
                     // \SETTEC
+                    // Found in IA item "little-busters-regular-edition-iso-only-2007"
                     new ContentMatchSet(new byte?[] { 0x5C, 0x53, 0x45, 0x54, 0x54, 0x45, 0x43 }, "Alpha-ROM"),
 
                     // SETTEC0000
+                    // Found in IA item "little-busters-regular-edition-iso-only-2007"
                     new ContentMatchSet(new byte?[] { 0x53, 0x45, 0x54, 0x54, 0x45, 0x43, 0x30, 0x30, 0x30, 0x30 }, "Alpha-ROM"),
                 };
 

--- a/BurnOutSharp/ProtectionType/ByteShield.cs
+++ b/BurnOutSharp/ProtectionType/ByteShield.cs
@@ -12,8 +12,8 @@ namespace BurnOutSharp.ProtectionType
         {
             var matchers = new List<PathMatchSet>
             {
-                new PathMatchSet(new PathMatch("Byteshield.dll", useEndsWith: true), "ByteShield"),
-                new PathMatchSet(new PathMatch(".bbz", useEndsWith: true), "ByteShield"),
+                new PathMatchSet(new PathMatch("Byteshield.dll", useEndsWith: true), "ByteShield (Unconfirmed - Please report to us on Github)"),
+                new PathMatchSet(new PathMatch(".bbz", useEndsWith: true), "ByteShield (Unconfirmed - Please report to us on Github)"),
             };
 
             return MatchUtil.GetAllMatches(files, matchers, any: true);
@@ -24,8 +24,8 @@ namespace BurnOutSharp.ProtectionType
         {
             var matchers = new List<PathMatchSet>
             {
-                new PathMatchSet(new PathMatch("Byteshield.dll", useEndsWith: true), "ByteShield"),
-                new PathMatchSet(new PathMatch(".bbz", useEndsWith: true), "ByteShield"),
+                new PathMatchSet(new PathMatch("Byteshield.dll", useEndsWith: true), "ByteShield (Unconfirmed - Please report to us on Github)"),
+                new PathMatchSet(new PathMatch(".bbz", useEndsWith: true), "ByteShield (Unconfirmed - Please report to us on Github)"),
             };
 
             return MatchUtil.GetFirstMatch(path, matchers, any: true);

--- a/BurnOutSharp/ProtectionType/CDDVDCops.cs
+++ b/BurnOutSharp/ProtectionType/CDDVDCops.cs
@@ -25,14 +25,14 @@ namespace BurnOutSharp.ProtectionType
                     {
                         0x43, 0x44, 0x2D, 0x43, 0x6F, 0x70, 0x73, 0x2C,
                         0x20, 0x20, 0x76, 0x65, 0x72, 0x2E, 0x20
-                    }, GetVersion, "CD-Cops"),
+                    }, GetVersion, "CD-Cops (Unconfirmed - Please report to us on Github)"),
 
                     // // DVD-Cops,  ver. 
                     new ContentMatchSet(new byte?[]
                     {
                         0x44, 0x56, 0x44, 0x2D, 0x43, 0x6F, 0x70, 0x73,
                         0x2C, 0x20, 0x20, 0x76, 0x65, 0x72, 0x2E, 0x20
-                    }, GetVersion, "DVD-Cops"),
+                    }, GetVersion, "DVD-Cops (Unconfirmed - Please report to us on Github)"),
                 };
 
                 return MatchUtil.GetFirstMatch(file, fileContent, contentMatchSets, includeDebug);
@@ -66,7 +66,7 @@ namespace BurnOutSharp.ProtectionType
                 {
                     0x43, 0x44, 0x2D, 0x43, 0x6F, 0x70, 0x73, 0x2C,
                     0x20, 0x20, 0x76, 0x65, 0x72, 0x2E, 0x20
-                }, GetVersion, "CD-Cops"),
+                }, GetVersion, "CD-Cops (Unconfirmed - Please report to us on Github)"),
             };
             
             return MatchUtil.GetFirstMatch(file, data, neMatchSets, includeDebug);
@@ -81,6 +81,7 @@ namespace BurnOutSharp.ProtectionType
                 return null;
 
             // Get the .grand section, if it exists -- TODO: Confirm is this is in DVD-Cops as well
+            // Found in "AGENTHUG.QZ_" in Redump entry 84517
             bool grandSection = pex.ContainsSection(".grand", exact: true);
             if (grandSection)
                 return "CD-Cops";
@@ -94,11 +95,13 @@ namespace BurnOutSharp.ProtectionType
             // TODO: Original had "CDCOPS.DLL" required and all the rest in a combined OR
             var matchers = new List<PathMatchSet>
             {
+                // Found in Redump entry 84517
                 new PathMatchSet(new PathMatch("CDCOPS.DLL", useEndsWith: true), "CD-Cops"),
-                new PathMatchSet(new PathMatch(".GZ_", useEndsWith: true), "CD-Cops"),
                 new PathMatchSet(new PathMatch(".W_X", useEndsWith: true), "CD-Cops"),
-                new PathMatchSet(new PathMatch(".Qz", useEndsWith: true), "CD-Cops"),
                 new PathMatchSet(new PathMatch(".QZ_", useEndsWith: true), "CD-Cops"),
+
+                new PathMatchSet(new PathMatch(".GZ_", useEndsWith: true), "CD-Cops (Unconfirmed - Please report to us on Github)"),
+                new PathMatchSet(new PathMatch(".Qz", useEndsWith: true), "CD-Cops (Unconfirmed - Please report to us on Github)"),
             };
 
             return MatchUtil.GetAllMatches(files, matchers, any: true);
@@ -109,11 +112,13 @@ namespace BurnOutSharp.ProtectionType
         {
             var matchers = new List<PathMatchSet>
             {
+                // Found in Redump entry 84517
                 new PathMatchSet(new PathMatch("CDCOPS.DLL", useEndsWith: true), "CD-Cops"),
-                new PathMatchSet(new PathMatch(".GZ_", useEndsWith: true), "CD-Cops"),
                 new PathMatchSet(new PathMatch(".W_X", useEndsWith: true), "CD-Cops"),
-                new PathMatchSet(new PathMatch(".Qz", useEndsWith: true), "CD-Cops"),
                 new PathMatchSet(new PathMatch(".QZ_", useEndsWith: true), "CD-Cops"),
+
+                new PathMatchSet(new PathMatch(".GZ_", useEndsWith: true), "CD-Cops (Unconfirmed - Please report to us on Github)"),
+                new PathMatchSet(new PathMatch(".Qz", useEndsWith: true), "CD-Cops (Unconfirmed - Please report to us on Github)"),
             };
 
             return MatchUtil.GetFirstMatch(path, matchers, any: true);

--- a/BurnOutSharp/ProtectionType/CDProtector.cs
+++ b/BurnOutSharp/ProtectionType/CDProtector.cs
@@ -13,10 +13,10 @@ namespace BurnOutSharp.ProtectionType
             // TODO: Verify if these are OR or AND
             var matchers = new List<PathMatchSet>
             {
-                new PathMatchSet(new PathMatch("_cdp16.dat", useEndsWith: true), "CD-Protector"),
-                new PathMatchSet(new PathMatch("_cdp16.dll", useEndsWith: true), "CD-Protector"),
-                new PathMatchSet(new PathMatch("_cdp32.dat", useEndsWith: true), "CD-Protector"),
-                new PathMatchSet(new PathMatch("_cdp32.dll", useEndsWith: true), "CD-Protector"),
+                new PathMatchSet(new PathMatch("_cdp16.dat", useEndsWith: true), "CD-Protector (Unconfirmed - Please report to us on Github)"),
+                new PathMatchSet(new PathMatch("_cdp16.dll", useEndsWith: true), "CD-Protector (Unconfirmed - Please report to us on Github)"),
+                new PathMatchSet(new PathMatch("_cdp32.dat", useEndsWith: true), "CD-Protector (Unconfirmed - Please report to us on Github)"),
+                new PathMatchSet(new PathMatch("_cdp32.dll", useEndsWith: true), "CD-Protector (Unconfirmed - Please report to us on Github)"),
             };
 
             return MatchUtil.GetAllMatches(files, matchers, any: true);
@@ -27,10 +27,10 @@ namespace BurnOutSharp.ProtectionType
         {
             var matchers = new List<PathMatchSet>
             {
-                new PathMatchSet(new PathMatch("_cdp16.dat", useEndsWith: true), "CD-Protector"),
-                new PathMatchSet(new PathMatch("_cdp16.dll", useEndsWith: true), "CD-Protector"),
-                new PathMatchSet(new PathMatch("_cdp32.dat", useEndsWith: true), "CD-Protector"),
-                new PathMatchSet(new PathMatch("_cdp32.dll", useEndsWith: true), "CD-Protector"),
+                new PathMatchSet(new PathMatch("_cdp16.dat", useEndsWith: true), "CD-Protector (Unconfirmed - Please report to us on Github)"),
+                new PathMatchSet(new PathMatch("_cdp16.dll", useEndsWith: true), "CD-Protector (Unconfirmed - Please report to us on Github)"),
+                new PathMatchSet(new PathMatch("_cdp32.dat", useEndsWith: true), "CD-Protector (Unconfirmed - Please report to us on Github)"),
+                new PathMatchSet(new PathMatch("_cdp32.dll", useEndsWith: true), "CD-Protector (Unconfirmed - Please report to us on Github)"),
             };
 
             return MatchUtil.GetFirstMatch(path, matchers, any: true);

--- a/BurnOutSharp/ProtectionType/CDX.cs
+++ b/BurnOutSharp/ProtectionType/CDX.cs
@@ -13,9 +13,9 @@ namespace BurnOutSharp.ProtectionType
             // TODO: Verify if these are OR or AND
             var matchers = new List<PathMatchSet>
             {
-                new PathMatchSet(new PathMatch("CHKCDX16.DLL", useEndsWith: true), "CD-X"),
-                new PathMatchSet(new PathMatch("CHKCDX32.DLL", useEndsWith: true), "CD-X"),
-                new PathMatchSet(new PathMatch("CHKCDXNT.DLL", useEndsWith: true), "CD-X"),
+                new PathMatchSet(new PathMatch("CHKCDX16.DLL", useEndsWith: true), "CD-X (Unconfirmed - Please report to us on Github)"),
+                new PathMatchSet(new PathMatch("CHKCDX32.DLL", useEndsWith: true), "CD-X (Unconfirmed - Please report to us on Github)"),
+                new PathMatchSet(new PathMatch("CHKCDXNT.DLL", useEndsWith: true), "CD-X (Unconfirmed - Please report to us on Github)"),
             };
 
             return MatchUtil.GetAllMatches(files, matchers, any: true);
@@ -26,9 +26,9 @@ namespace BurnOutSharp.ProtectionType
         {
             var matchers = new List<PathMatchSet>
             {
-                new PathMatchSet(new PathMatch("CHKCDX16.DLL", useEndsWith: true), "CD-X"),
-                new PathMatchSet(new PathMatch("CHKCDX32.DLL", useEndsWith: true), "CD-X"),
-                new PathMatchSet(new PathMatch("CHKCDXNT.DLL", useEndsWith: true), "CD-X"),
+                new PathMatchSet(new PathMatch("CHKCDX16.DLL", useEndsWith: true), "CD-X (Unconfirmed - Please report to us on Github)"),
+                new PathMatchSet(new PathMatch("CHKCDX32.DLL", useEndsWith: true), "CD-X (Unconfirmed - Please report to us on Github)"),
+                new PathMatchSet(new PathMatch("CHKCDXNT.DLL", useEndsWith: true), "CD-X (Unconfirmed - Please report to us on Github)"),
             };
 
             return MatchUtil.GetFirstMatch(path, matchers, any: true);

--- a/BurnOutSharp/ProtectionType/CodeLock.cs
+++ b/BurnOutSharp/ProtectionType/CodeLock.cs
@@ -22,7 +22,7 @@ namespace BurnOutSharp.ProtectionType
                      {
                          0x43, 0x4F, 0x44, 0x45, 0x2D, 0x4C, 0x4F, 0x43,
                          0x4B, 0x2E, 0x4F, 0x43, 0x58
-                     }, "CodeLock / CodeLok / CopyLok"),
+                     }, "CodeLock / CodeLok / CopyLok (Unconfirmed - Please report to us on Github)"),
                  };
 
                 return MatchUtil.GetFirstMatch(file, fileContent, contentMatchSets, includeDebug);
@@ -38,8 +38,9 @@ namespace BurnOutSharp.ProtectionType
             var sections = pex?.SectionTable;
             if (sections == null)
                 return null;
-            
+
             // If there are more than 2 icd-prefixed sections, then we have a match
+            // Found in Redump entry 31557.
             int icdSectionCount = pex.GetSectionNames().Count(s => s.StartsWith("icd"));
             if (icdSectionCount >= 2)
                 return "CodeLock / CodeLok / CopyLok";

--- a/BurnOutSharp/ProtectionType/DVDCrypt.cs
+++ b/BurnOutSharp/ProtectionType/DVDCrypt.cs
@@ -12,7 +12,7 @@ namespace BurnOutSharp.ProtectionType
         {
             var matchers = new List<PathMatchSet>
             {
-                new PathMatchSet(new PathMatch("DvdCrypt.pdb", useEndsWith: true), "DVD Crypt"),
+                new PathMatchSet(new PathMatch("DvdCrypt.pdb", useEndsWith: true), "DVD Crypt (Unconfirmed - Please report to us on Github)"),
             };
 
             return MatchUtil.GetAllMatches(files, matchers, any: true);
@@ -23,7 +23,7 @@ namespace BurnOutSharp.ProtectionType
         {
             var matchers = new List<PathMatchSet>
             {
-                new PathMatchSet(new PathMatch("DvdCrypt.pdb", useEndsWith: true), "DVD Crypt"),
+                new PathMatchSet(new PathMatch("DvdCrypt.pdb", useEndsWith: true), "DVD Crypt (Unconfirmed - Please report to us on Github)"),
             };
 
             return MatchUtil.GetFirstMatch(path, matchers, any: true);

--- a/BurnOutSharp/ProtectionType/DVDMoviePROTECT.cs
+++ b/BurnOutSharp/ProtectionType/DVDMoviePROTECT.cs
@@ -23,7 +23,7 @@ namespace BurnOutSharp.ProtectionType
                     FileInfo ifofile = new FileInfo(Path.Combine(bupfile.DirectoryName, bupfile.Name.Substring(0, bupfile.Name.Length - bupfile.Extension.Length) + ".ifo"));
                     if (bupfile.Length != ifofile.Length)
                     {
-                        protections.Enqueue("DVD-Movie-PROTECT");
+                        protections.Enqueue("DVD-Movie-PROTECT (Unconfirmed - Please report to us on Github)");
                         break;
                     }
                 }

--- a/BurnOutSharp/ProtectionType/FreeLock.cs
+++ b/BurnOutSharp/ProtectionType/FreeLock.cs
@@ -12,7 +12,7 @@ namespace BurnOutSharp.ProtectionType
         {
             var matchers = new List<PathMatchSet>
             {
-                new PathMatchSet(new PathMatch("FREELOCK.IMG", useEndsWith: true), "FreeLock"),
+                new PathMatchSet(new PathMatch("FREELOCK.IMG", useEndsWith: true), "FreeLock (Unconfirmed - Please report to us on Github)"),
             };
 
             return MatchUtil.GetAllMatches(files, matchers, any: true);
@@ -23,7 +23,7 @@ namespace BurnOutSharp.ProtectionType
         {
             var matchers = new List<PathMatchSet>
             {
-                new PathMatchSet(new PathMatch("FREELOCK.IMG", useEndsWith: true), "FreeLock"),
+                new PathMatchSet(new PathMatch("FREELOCK.IMG", useEndsWith: true), "FreeLock (Unconfirmed - Please report to us on Github)"),
             };
 
             return MatchUtil.GetFirstMatch(path, matchers, any: true);

--- a/BurnOutSharp/ProtectionType/IndyVCD.cs
+++ b/BurnOutSharp/ProtectionType/IndyVCD.cs
@@ -13,8 +13,8 @@ namespace BurnOutSharp.ProtectionType
             // TODO: Verify if these are OR or AND
             var matchers = new List<PathMatchSet>
             {
-                new PathMatchSet(new PathMatch("INDYVCD.AX", useEndsWith: true), "IndyVCD"),
-                new PathMatchSet(new PathMatch("INDYMP3.idt", useEndsWith: true), "IndyVCD"),
+                new PathMatchSet(new PathMatch("INDYVCD.AX", useEndsWith: true), "IndyVCD (Unconfirmed - Please report to us on Github)"),
+                new PathMatchSet(new PathMatch("INDYMP3.idt", useEndsWith: true), "IndyVCD (Unconfirmed - Please report to us on Github)"),
             };
 
             return MatchUtil.GetAllMatches(files, matchers, any: true);
@@ -25,8 +25,8 @@ namespace BurnOutSharp.ProtectionType
         {
             var matchers = new List<PathMatchSet>
             {
-                new PathMatchSet(new PathMatch("INDYVCD.AX", useEndsWith: true), "IndyVCD"),
-                new PathMatchSet(new PathMatch("INDYMP3.idt", useEndsWith: true), "IndyVCD"),
+                new PathMatchSet(new PathMatch("INDYVCD.AX", useEndsWith: true), "IndyVCD (Unconfirmed - Please report to us on Github)"),
+                new PathMatchSet(new PathMatch("INDYMP3.idt", useEndsWith: true), "IndyVCD (Unconfirmed - Please report to us on Github)"),
             };
 
             return MatchUtil.GetFirstMatch(path, matchers, any: true);

--- a/BurnOutSharp/ProtectionType/IndyVCD.cs
+++ b/BurnOutSharp/ProtectionType/IndyVCD.cs
@@ -5,6 +5,10 @@ using BurnOutSharp.Matching;
 
 namespace BurnOutSharp.ProtectionType
 {
+    // http://www.vsubhash.in/ubuntu-gnome-diary.html#play_copy_protected_vcds_indygenius_indyvcd
+    // https://forum.videohelp.com/threads/241664-How-to-copy-this-vcd
+    // https://forum.videohelp.com/threads/315331-VCD-cannot-play-in-PC-but-can-play-in-DVD-player
+    // https://answers.microsoft.com/en-us/windows/forum/all/call-to-dii-register-server-failed/16cb344e-979a-4fb6-a8cd-1c9bc4dd14dd
     public class IndyVCD : IPathCheck
     {
         /// <inheritdoc/>

--- a/BurnOutSharp/ProtectionType/KeyLock.cs
+++ b/BurnOutSharp/ProtectionType/KeyLock.cs
@@ -19,7 +19,7 @@ namespace BurnOutSharp.ProtectionType
                     {
                         0x4B, 0x45, 0x59, 0x2D, 0x4C, 0x4F, 0x43, 0x4B,
                         0x20, 0x43, 0x4F, 0x4D, 0x4D, 0x41, 0x4E, 0x44
-                    }, "Key-Lock (Dongle)"),
+                    }, "Key-Lock (Dongle) (Unconfirmed - Please report to us on Github)"),
                 };
 
                 return MatchUtil.GetFirstMatch(file, fileContent, contentMatchSets, includeDebug);

--- a/BurnOutSharp/ProtectionType/ProtectDVDVideo.cs
+++ b/BurnOutSharp/ProtectionType/ProtectDVDVideo.cs
@@ -22,7 +22,7 @@ namespace BurnOutSharp.ProtectionType
                     FileInfo ifofile = new FileInfo(ifofiles[i]);
                     if (ifofile.Length == 0)
                     {
-                        protections.Enqueue("Protect DVD-Video");
+                        protections.Enqueue("Protect DVD-Video (Unconfirmed - Please report to us on Github)");
                         break;
                     }
                 }

--- a/BurnOutSharp/ProtectionType/RingPROTECH.cs
+++ b/BurnOutSharp/ProtectionType/RingPROTECH.cs
@@ -21,7 +21,7 @@ namespace BurnOutSharp.ProtectionType
                     {
                         0x00, 0x41, 0x6C, 0x6C, 0x6F, 0x63, 0x61, 0x74,
                         0x6F, 0x72, 0x00, 0x00, 0x00, 0x00
-                    }, "Ring PROTECH / ProRing [Check disc for physical ring]"),
+                    }, "Ring PROTECH / ProRing [Check disc for physical ring] (Unconfirmed - Please report to us on Github)"),
                 };
 
                 return MatchUtil.GetFirstMatch(file, fileContent, contentMatchSets, includeDebug);
@@ -37,7 +37,7 @@ namespace BurnOutSharp.ProtectionType
         {
             var matchers = new List<PathMatchSet>
             {
-                new PathMatchSet(new PathMatch("protect.pro", useEndsWith: true), "Ring PROTECH / ProRing [Check disc for physical ring]"),
+                new PathMatchSet(new PathMatch("protect.pro", useEndsWith: true), "Ring PROTECH / ProRing [Check disc for physical ring] (Unconfirmed - Please report to us on Github)"),
             };
 
             return MatchUtil.GetAllMatches(files, matchers, any: true);
@@ -48,7 +48,7 @@ namespace BurnOutSharp.ProtectionType
         {
             var matchers = new List<PathMatchSet>
             {
-                new PathMatchSet(new PathMatch("protect.pro", useEndsWith: true), "Ring PROTECH / ProRing [Check disc for physical ring]"),
+                new PathMatchSet(new PathMatch("protect.pro", useEndsWith: true), "Ring PROTECH / ProRing [Check disc for physical ring] (Unconfirmed - Please report to us on Github)"),
             };
 
             return MatchUtil.GetFirstMatch(path, matchers, any: true);

--- a/BurnOutSharp/ProtectionType/RingPROTECH.cs
+++ b/BurnOutSharp/ProtectionType/RingPROTECH.cs
@@ -6,6 +6,7 @@ using BurnOutSharp.Matching;
 namespace BurnOutSharp.ProtectionType
 {
     // Renamed to ProRing at some point
+    // TODO: Investigate Redump entry 82475, which PiD detects as having "Optgraph Copy-X / Ring-Protech".
     public class RingPROTECH : IContentCheck, IPathCheck
     {
         /// <inheritdoc/>
@@ -37,7 +38,8 @@ namespace BurnOutSharp.ProtectionType
         {
             var matchers = new List<PathMatchSet>
             {
-                new PathMatchSet(new PathMatch("protect.pro", useEndsWith: true), "Ring PROTECH / ProRing [Check disc for physical ring] (Unconfirmed - Please report to us on Github)"),
+                // Found in Redump entry 94161
+                new PathMatchSet(new PathMatch("protect.pro", useEndsWith: true), "Ring PROTECH / ProRing [Check disc for physical ring]"),
             };
 
             return MatchUtil.GetAllMatches(files, matchers, any: true);
@@ -48,7 +50,8 @@ namespace BurnOutSharp.ProtectionType
         {
             var matchers = new List<PathMatchSet>
             {
-                new PathMatchSet(new PathMatch("protect.pro", useEndsWith: true), "Ring PROTECH / ProRing [Check disc for physical ring] (Unconfirmed - Please report to us on Github)"),
+                // Found in Redump entry 94161
+                new PathMatchSet(new PathMatch("protect.pro", useEndsWith: true), "Ring PROTECH / ProRing [Check disc for physical ring]"),
             };
 
             return MatchUtil.GetFirstMatch(path, matchers, any: true);

--- a/BurnOutSharp/ProtectionType/SoftLock.cs
+++ b/BurnOutSharp/ProtectionType/SoftLock.cs
@@ -13,8 +13,8 @@ namespace BurnOutSharp.ProtectionType
             // TODO: Verify if these are OR or AND
             var matchers = new List<PathMatchSet>
             {
-                new PathMatchSet(new PathMatch("SOFTLOCKI.dat", useEndsWith: true), "SoftLock"),
-                new PathMatchSet(new PathMatch("SOFTLOCKC.dat", useEndsWith: true), "SoftLock"),
+                new PathMatchSet(new PathMatch("SOFTLOCKI.dat", useEndsWith: true), "SoftLock (Unconfirmed - Please report to us on Github)"),
+                new PathMatchSet(new PathMatch("SOFTLOCKC.dat", useEndsWith: true), "SoftLock (Unconfirmed - Please report to us on Github)"),
             };
 
             return MatchUtil.GetAllMatches(files, matchers, any: true);
@@ -25,8 +25,8 @@ namespace BurnOutSharp.ProtectionType
         {
             var matchers = new List<PathMatchSet>
             {
-                new PathMatchSet(new PathMatch("SOFTLOCKI.dat", useEndsWith: true), "SoftLock"),
-                new PathMatchSet(new PathMatch("SOFTLOCKC.dat", useEndsWith: true), "SoftLock"),
+                new PathMatchSet(new PathMatch("SOFTLOCKI.dat", useEndsWith: true), "SoftLock (Unconfirmed - Please report to us on Github)"),
+                new PathMatchSet(new PathMatch("SOFTLOCKC.dat", useEndsWith: true), "SoftLock (Unconfirmed - Please report to us on Github)"),
             };
 
             return MatchUtil.GetFirstMatch(path, matchers, any: true);

--- a/BurnOutSharp/ProtectionType/TZCopyProtector.cs
+++ b/BurnOutSharp/ProtectionType/TZCopyProtector.cs
@@ -12,7 +12,7 @@ namespace BurnOutSharp.ProtectionType
         {
             var matchers = new List<PathMatchSet>
             {
-                new PathMatchSet(new PathMatch("_742893.016", useEndsWith: true), "TZCopyProtector"),
+                new PathMatchSet(new PathMatch("_742893.016", useEndsWith: true), "TZCopyProtector (Unconfirmed - Please report to us on Github)"),
             };
 
             return MatchUtil.GetAllMatches(files, matchers, any: true);
@@ -23,7 +23,7 @@ namespace BurnOutSharp.ProtectionType
         {
             var matchers = new List<PathMatchSet>
             {
-                new PathMatchSet(new PathMatch("_742893.016", useEndsWith: true), "TZCopyProtector"),
+                new PathMatchSet(new PathMatch("_742893.016", useEndsWith: true), "TZCopyProtector (Unconfirmed - Please report to us on Github)"),
             };
 
             return MatchUtil.GetFirstMatch(path, matchers, any: true);

--- a/BurnOutSharp/ProtectionType/Winlock.cs
+++ b/BurnOutSharp/ProtectionType/Winlock.cs
@@ -12,7 +12,7 @@ namespace BurnOutSharp.ProtectionType
         {
             var matchers = new List<PathMatchSet>
             {
-                new PathMatchSet(new PathMatch("WinLock.PSX", useEndsWith: true), "Winlock"),
+                new PathMatchSet(new PathMatch("WinLock.PSX", useEndsWith: true), "Winlock (Unconfirmed - Please report to us on Github)"),
             };
 
             return MatchUtil.GetAllMatches(files, matchers, any: true);
@@ -23,7 +23,7 @@ namespace BurnOutSharp.ProtectionType
         {
             var matchers = new List<PathMatchSet>
             {
-                new PathMatchSet(new PathMatch("WinLock.PSX", useEndsWith: true), "Winlock"),
+                new PathMatchSet(new PathMatch("WinLock.PSX", useEndsWith: true), "Winlock (Unconfirmed - Please report to us on Github)"),
             };
 
             return MatchUtil.GetFirstMatch(path, matchers, any: true);

--- a/README.md
+++ b/README.md
@@ -30,13 +30,13 @@ Below is a list of protections detected by BurnOutSharp. The two columns explain
 | ActiveMARK | True | False | Version 5 unconfirmed²; version finding incomplete |
 | AegiSoft License Manager | True | True | |
 | Alpha-DVD | False | True | Unconfirmed¹ |
-| Alpha-ROM | True | False | Unconfirmed¹ |
+| Alpha-ROM | True | False | |
 | BD+ | False | True | |
 | Bitpool | False | True | |
 | ByteShield | False | True | Unconfirmed¹ |
 | Cactus Data Shield | True | True | |
 | CD-Cops / DVD-Cops | True | True | Partially unconfirmed² |
-| CD-Lock | True | True | Unconfirmed¹ |
+| CD-Lock | True | True | |
 | CD-Protector | False | True | Unconfirmed¹ |
 | CD-X | False | True | Unconfirmed¹ |
 | CDSHiELD SE | True | False | |
@@ -76,7 +76,7 @@ Below is a list of protections detected by BurnOutSharp. The two columns explain
 | PlayStation Anti-modchip | True | False | En/Jp, not "Red Hand"; PSX executables only |
 | Ring PROTECH / ProRing | True | True | Unconfirmed¹ |
 | SafeDisc / SafeCast | True | True | Can't distinguish between some versions of SafeDisc and SafeCast |
-| SafeLock | False | True | Unconfirmed¹ |
+| SafeLock | False | True | |
 | SecuROM | True | True | v8.x and White Label detected partially² |
 | SmartE | True | True | |
 | SoftLock | False | True | Unconfirmed¹ |

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Below is a list of protections detected by BurnOutSharp. The two columns explain
 | ProtectDISC / VOB ProtectCD/DVD | True | False | |
 | Protect DVD-Video | False | True | Unconfirmed¹ |
 | PlayStation Anti-modchip | True | False | En/Jp, not "Red Hand"; PSX executables only |
-| Ring PROTECH / ProRing | True | True | Unconfirmed¹ |
+| Ring PROTECH / ProRing | True | True | Partially unconfirmed² |
 | SafeDisc / SafeCast | True | True | Can't distinguish between some versions of SafeDisc and SafeCast |
 | SafeLock | False | True | |
 | SecuROM | True | True | v8.x and White Label detected partially² |


### PR DESCRIPTION
* Add notes to unconfirmed detections to let users know what detections we need samples of.

* Add sources for some protections to confirm them.