### PR TITLE
Update GCF output string for encrypted GCFs

### DIFF
--- a/BinaryObjectScanner/FileType/GCF.cs
+++ b/BinaryObjectScanner/FileType/GCF.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 
 namespace BinaryObjectScanner.FileType
@@ -20,11 +21,11 @@ namespace BinaryObjectScanner.FileType
 
             // While there is a depot-level encrypted flag on the GCF, it's unfortunately completely unreliable.
             // Technically speaking, there are some known GCFs that only have some files encrypted. HL2 discs from
-            // 2004 have a base_source_engine.gcf (depot 200) like this. However, currently unsure of the performance
-            // impacts of looping the entirety of _wrapper.Files[] just to cover a fairly niche edge case
+            // 2004 have several GCFs like this, one being base_source_engine.gcf (depot 200). Thus, it's necessary
+            // to iterate all file info to check if any files are encrypted
             bool encrypted = false;
             if (_wrapper.Files != null && _wrapper.Files.Length > 0)
-                encrypted = _wrapper.Files[0].Encrypted;
+                encrypted = Array.Exists(_wrapper.Files, fileInfo => fileInfo.Encrypted);
 
             // Only note encryption status if the GCF is encrypted
             string encryptedString = encrypted ? ", encrypted" : "";

--- a/BinaryObjectScanner/FileType/GCF.cs
+++ b/BinaryObjectScanner/FileType/GCF.cs
@@ -16,19 +16,19 @@ namespace BinaryObjectScanner.FileType
             // Filename is worth reporting, since it's descriptive and has to match the Steam2 CDN in order to work.
             string fileName = Path.GetFileName(file);
             uint depotId = _wrapper.Model.Header.CacheID;
-            uint manifestVersion = _wrapper.Model.Header.LastVersionPlayed;
+            uint depotVersion = _wrapper.Model.Header.LastVersionPlayed;
 
-            // At the moment, all samples of GCF files on redump are unencrypted. Combined with being uncertain about
-            // whether this is the best way to check whether the GCF is encrypted, this block will be left commented
-            // out until further research is done.
-            // bool encrypted = false;
-            // if (_wrapper.Files != null && _wrapper.Files.Length > 0)
-            //     encrypted = _wrapper.Files[0].Encrypted;
+            // While there is a depot-level encrypted flag on the GCF, it's unfortunately completely unreliable.
+            // Technically speaking, there are some known GCFs that only have some files encrypted. HL2 discs from
+            // 2004 have a base_source_engine.gcf (depot 200) like this. However, currently unsure of the performance
+            // impacts of looping the entirety of _wrapper.Files[] just to cover a fairly niche edge case
+            bool encrypted = false;
+            if (_wrapper.Files != null && _wrapper.Files.Length > 0)
+                encrypted = _wrapper.Files[0].Encrypted;
 
-            // string encryptedString = encrypted ? "encrypted" : "unencrypted";
-            // string returnString = $"{fileName} - {depotId} (v{manifestVersion}, {encryptedString})";
-
-            string returnString = $"{fileName} - {depotId} (v{manifestVersion})";
+            // Only note encryption status if the GCF is encrypted
+            string encryptedString = encrypted ? ", encrypted" : "";
+            string returnString = $"{fileName} - {depotId} (v{depotVersion}{encryptedString})";
             return returnString;
         }
     }


### PR DESCRIPTION
This is not even remotely a priority, this is a minor change and I just wanted to push it before I forgot about it. You obv have much more important things to work on at the moment.

Updates GCF output string to note when the GCF is encrypted. I was wrong that there aren't many encrypted GCFs, there's a bunch.